### PR TITLE
Recognize button 0 as "left click"

### DIFF
--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -411,6 +411,7 @@ let TaskBarItem = GObject.registerClass(
                         this.mouseData.pressed = false;
                         this.mouseData.dragged = false;
                         switch (event.get_button()) {
+                            case 0:
                             case 1:
                                 this.emit('left-clicked');
                                 break;


### PR DESCRIPTION
`get_button()` may return 0 when the pressed button isn't recognized by clutter, f.e. on certain touch devices. To provide basic functionality it should be handled as a normal left click.

Fixed #287.