### PR TITLE
Master fixes

### DIFF
--- a/src/module/hotKeysModule.js
+++ b/src/module/hotKeysModule.js
@@ -284,5 +284,13 @@ var HotKeysModule = class HotKeysModule {
         this.actionIdToNameMap.set(actionId, name);
     }
 
-    destroy() {}
+    destroy() {
+        this.actionIdToNameMap.forEach(key => {
+                Main.wm.removeKeybinding(key);
+                this.actionIdToNameMap.delete(key);
+            });
+        if (this.connectId) {
+            global.window_manager.disconnect(this.connectId);
+        }
+    }
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -79,9 +79,13 @@ var reparentActor = (actor, parent) => {
     if (currentParent) {
         currentParent.remove_child(actor);
     }
-    parent.add_child(actor);
-    if (isFocused) {
-        actor.grab_key_focus();
+    try { // FIXME: workaround from crash on disabling = status area gone
+        parent.add_child(actor);
+        if (isFocused) {
+            actor.grab_key_focus();
+        }
+    } catch (error) {
+        logError(error, '[material-shell.index]');
     }
     Me.reparentInProgress = false;
 };


### PR DESCRIPTION
1. Properly disconnect signals and keybindings on destroy in hotKeysModule.js. (https://github.com/material-shell/material-shell/commit/a92e4525864552fc21bf4cfdc912c47457f08c89)

2. Workaround from crash on disabling (status area gone). https://github.com/material-shell/material-shell/commit/2f38b0e57fb28c5ebef16aa03f1b44473914e6d4