### PR TITLE
Fixed Wayland crash after latest commits

### DIFF
--- a/src/module/overrideModule.js
+++ b/src/module/overrideModule.js
@@ -39,21 +39,32 @@ var OverrideModule = class OverrideModule {
         const _shouldAnimateActor = WindowManager.prototype._shouldAnimateActor;
         WindowManager.prototype._shouldAnimateActor = function () {
             let actor = arguments[0];
+            let types = arguments[1];
+
+            if (
+                !actor ||
+                this._skippedActors.delete(actor) ||
+                !this._shouldAnimate() ||
+                !actor.get_texture()
+            ) {
+                return false;
+            }
+
             if (actor.manipulateByMs && !actor.completeIsRequested) {
                 actor.completeIsRequested = true;
                 return true;
             }
-            return _shouldAnimateActor.apply(this, arguments);
+            return types.includes(actor.meta_window.get_window_type());
         };
         this.windowManagersFunctionToRestore.push([
             WindowManager.prototype._shouldAnimateActor,
             _shouldAnimateActor,
         ]);
 
-        const _prepareAnimationInfo =
-            WindowManager.prototype._prepareAnimationInfo;
+        const _prepareAnimationInfo = WindowManager.prototype._prepareAnimationInfo;
         WindowManager.prototype._prepareAnimationInfo = function () {
             let actor = arguments[1];
+            if (!actor) return;
             if (actor.manipulateByMs) {
                 delete actor.manipulateByMs;
                 return;


### PR DESCRIPTION
Using `Glib.idle_add` to call both maximize and minimize prevented the crash in Wayland. I have also implemented `_shouldAnimateActor` prototype closer to [source](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/gnome-3-36/js/ui/windowManager.js). As a bonus, I haven't seen any more calls to the 'hack' in msWindow, but I am not sure if it is needed or not for other reasons (I have made some tests in both Wayland and XOrg), so I left that part.