### PR TITLE
Hotkeys to increase/decrease ratios in Split and Ratio layouts

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -69,6 +69,10 @@ const hotKeysLabels = {
         'Cycle around the tiling layout on the current workspace',
     'reverse-cycle-tiling-layout':
         'Cycle around in reverse order the tiling layout on the current workspace',
+    'customize-layout-increase':
+        'Increase ratio of windows in workspace (works on Split and Ratio layouts).',
+    'customize-layout-decrease':
+        'Decrease ratio of windows in workspace (works on Split and Ratio layouts).',
     'toggle-material-shell-ui':
         'Toggle the material-shell UI to simulate fullscreen',
     'navigate-to-workspace-1': 'Navigate to workspace 1',
@@ -85,7 +89,7 @@ const hotKeysLabels = {
 
 const layouts = {
     maximize: 'Maximize all windows',
-    split: 'Put all windows side by side, two at a time',
+    split: 'Put all windows side by side (from 2 to 4)',
     float: 'Windows are not tiled',
     half: 'Tile windows according to screen ratio',
     'half-horizontal': 'Tile windows horizontally',
@@ -267,7 +271,7 @@ function layoutsTab(notebook) {
         settings.bind(layout, item, 'active', Gio.SettingsBindFlags.DEFAULT);
         rows.push(makeItemRow(name, description, item));
         if (layout === 'ratio') {
-            const ratio = Gtk.SpinButton.new_with_range(0, 1, 0.01);
+            const ratio = Gtk.SpinButton.new_with_range(0.2, 0.8, 0.01);
             settings.bind(
                 'ratio-value',
                 ratio.get_adjustment(),

--- a/schemas/bindings.gschema.xml
+++ b/schemas/bindings.gschema.xml
@@ -72,6 +72,20 @@
         Cycle around in reverse order the tiling layout on the current workspace
       </description>
     </key>
+    <key name="customize-layout-increase" type="as">
+      <default><![CDATA[['<Super>k']]]></default>
+      <summary>Increase ratio of windows in workspace (works on Split and Ratio layouts).</summary>
+      <description>
+        Increase ratio of windows in workspace (works on Split and Ratio layouts).
+      </description>
+    </key>
+    <key name="customize-layout-decrease" type="as">
+      <default><![CDATA[['<Super>j']]]></default>
+      <summary>Decrease ratio of windows in workspace (works on Split and Ratio layouts).</summary>
+      <description>
+        Decrease ratio of windows in workspace (works on Split and Ratio layouts).
+      </description>
+    </key>
     <key name="toggle-material-shell-ui" type="as">
       <default><![CDATA[['<Super>Escape']]]></default>
       <summary>Toggle the material-shell UI to simulate fullscreen</summary>

--- a/schemas/layouts.gschema.xml
+++ b/schemas/layouts.gschema.xml
@@ -8,7 +8,7 @@
     <key name="split" type="b">
       <default>true</default>
       <summary>Split layout</summary>
-      <description>Put all windows side by side, two at a time</description>
+      <description>Put all windows side by side (from 2 to 4)</description>
     </key>
     <key name="half" type="b">
       <default>true</default>

--- a/src/layout/msWorkspace/tilingLayouts/baseTiling.js
+++ b/src/layout/msWorkspace/tilingLayouts/baseTiling.js
@@ -371,5 +371,8 @@ var BaseTilingLayout = GObject.registerClass(
                 });
             }
         }
+
+        onCustomizingHotkeyDecrease() {}
+        onCustomizingHotkeyIncrease() {}
     }
 );

--- a/src/layout/msWorkspace/tilingLayouts/custom/ratio.js
+++ b/src/layout/msWorkspace/tilingLayouts/custom/ratio.js
@@ -6,6 +6,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 const {
     BaseTilingLayout,
 } = Me.imports.src.layout.msWorkspace.tilingLayouts.baseTiling;
+const { getSettings } = Me.imports.src.utils.settings;
 
 /* exported RatioLayout */
 var RatioLayout = GObject.registerClass(
@@ -22,10 +23,12 @@ var RatioLayout = GObject.registerClass(
             tileable.y = y;
             tileable.width = width;
             tileable.height = height;
+            this.ratio = Me.tilingManager.ratio;
+            this.layoutsSettings = getSettings('layouts');
         }
 
         tile(box, index, last) {
-            const ratio = Me.tilingManager.ratio;
+            let ratio = this.ratio;
             let areaBox = {
                 x: box.x1,
                 y: box.y1,
@@ -71,6 +74,22 @@ var RatioLayout = GObject.registerClass(
                     height: area.height * (1 - ratio),
                 };
             }, areaBox);
+        }
+
+        onCustomizingHotkeyDecrease() {
+            if (this.ratio < 0.2) return;
+            this.ratio = Math.max(0, this.ratio - 0.05);
+            this.layoutsSettings.set_double('ratio-value', this.ratio);
+            this.tileAll();
+            this.layout_changed();
+        }
+
+        onCustomizingHotkeyIncrease() {
+            if (this.ratio > 0.8) return;
+            this.ratio = Math.min(1, this.ratio + 0.05);
+            this.layoutsSettings.set_double('ratio-value', this.ratio);
+            this.tileAll();
+            this.layout_changed();
         }
     }
 );

--- a/src/manager/tilingManager.js
+++ b/src/manager/tilingManager.js
@@ -141,7 +141,7 @@ var TilingManager = class TilingManager extends MsManager {
                 }
                 let layout = msWorkspace.tilingLayout;
 
-                layout.onTile();
+                layout.tileAll();
                 //this.dialogLayout.onTile(dialogWindows, monitor);
             }
 

--- a/src/module/hotKeysModule.js
+++ b/src/module/hotKeysModule.js
@@ -22,6 +22,8 @@ var KeyBindingAction = {
     // layout actions
     CYCLE_TILING_LAYOUT: 'cycle-tiling-layout',
     REVERSE_CYCLE_TILING_LAYOUT: 'reverse-cycle-tiling-layout',
+    CUSTOMIZE_LAYOUT_INCREASE: 'customize-layout-increase',
+    CUSTOMIZE_LAYOUT_DECREASE: 'customize-layout-decrease',
     TOGGLE_MATERIAL_SHELL_UI: 'toggle-material-shell-ui',
     // workspaces actions
     PREVIOUS_WORKSPACE: 'previous-workspace',
@@ -216,6 +218,22 @@ var HotKeysModule = class HotKeysModule {
             () => {
                 const msWorkspace = Me.msWorkspaceManager.getActiveMsWorkspace();
                 msWorkspace.nextTiling(-1);
+            }
+        );
+
+        this.actionNameToActionMap.set(
+            KeyBindingAction.CUSTOMIZE_LAYOUT_INCREASE,
+            () => {
+                const msWorkspace = Me.msWorkspaceManager.getActiveMsWorkspace();
+                msWorkspace.tilingLayout.onCustomizingHotkeyIncrease();
+            }
+        );
+
+        this.actionNameToActionMap.set(
+            KeyBindingAction.CUSTOMIZE_LAYOUT_DECREASE,
+            () => {
+                const msWorkspace = Me.msWorkspaceManager.getActiveMsWorkspace();
+                msWorkspace.tilingLayout.onCustomizingHotkeyDecrease();
             }
         );
 


### PR DESCRIPTION
- Split layout can go form 2 to 4 windows (it is _split_, after all), independently (always starts at 2 tho) 
- Ratio goes form 0.2 to 0.8
- Avoids unnecessary redraws
- Ratio is saved, so all workspaces will use the same ratio

Closes #164 

Base code from #141, all credits to @nununoisy 

**Edit: This should applied after #355** 