### PR TITLE
Apply gaps for split layout and never for App Launcher

### DIFF
--- a/src/layout/msWorkspace/tilingLayouts/baseTiling.js
+++ b/src/layout/msWorkspace/tilingLayouts/baseTiling.js
@@ -294,7 +294,11 @@ var BaseTilingLayout = GObject.registerClass(
             const screenGap = Me.tilingManager.screenGap;
             const useScreenGap = Me.tilingManager.useScreenGap;
 
-            if (!gap && (!useScreenGap || !screenGap)) {
+            if (
+                (!gap && (!useScreenGap || !screenGap)) ||
+                // Never apply gaps if App Launcher is the only tileable
+                this.msWorkspace.tileableList.length < 2
+             ) {
                 return { x, y, width, height };
             }
             const bounds = this.getWorkspaceBounds();

--- a/src/layout/msWorkspace/tilingLayouts/split.js
+++ b/src/layout/msWorkspace/tilingLayouts/split.js
@@ -123,28 +123,49 @@ var SplitLayout = GObject.registerClass(
         }
 
         tileTileable(tileable, box, index, siblingLength) {
-            let verticalPortion = this.vertical
-                ? box.get_height() / WINDOW_PER_SCREEN
-                : box.get_height();
-            let horizontalPortion = this.vertical
-                ? box.get_width()
-                : box.get_width() / WINDOW_PER_SCREEN;
-            if (this.activeTileableList.includes(tileable)) {
-                let activeIndex = this.activeTileableList.indexOf(tileable);
-                if (this.vertical) {
-                    tileable.x = box.x1;
-                    tileable.y = box.y1 + activeIndex * verticalPortion;
-                } else {
-                    tileable.x = box.x1 + activeIndex * horizontalPortion;
-                    tileable.y = box.y1;
-                }
-            } else {
+            // Do nothing if App Launcher is the only tileable
+            if (index === 0 && siblingLength === 1) {
                 tileable.x = box.x1;
                 tileable.y = box.y1;
-            }
+                tileable.width = box.get_width();
+                tileable.height = box.get_height();
+           } else {
+               let x, y, width, height;
+               let verticalPortion = this.vertical
+                   ? box.get_height() / WINDOW_PER_SCREEN
+                   : box.get_height();
+               let horizontalPortion = this.vertical
+                   ? box.get_width()
+                   : box.get_width() / WINDOW_PER_SCREEN;
+               if (this.activeTileableList.includes(tileable)) {
+                   let activeIndex = this.activeTileableList.indexOf(tileable);
+                   if (this.vertical) {
+                       x = box.x1;
+                       y = box.y1 + activeIndex * verticalPortion;
+                   } else {
+                       x = box.x1 + activeIndex * horizontalPortion;
+                       y = box.y1;
+                   }
+               } else {
+                   x = box.x1;
+                   y = box.y1;
+               }
 
-            tileable.width = horizontalPortion;
-            tileable.height = verticalPortion;
+               width = horizontalPortion;
+               height = verticalPortion;
+
+               let {
+                   x: gapX,
+                   y: gapY,
+                   width: gapWidth,
+                   height: gapHeight,
+               } = this.applyGaps(x, y, width, height);
+
+               tileable.x = gapX;
+               tileable.y = gapY;
+               tileable.width = gapWidth;
+               tileable.height = gapHeight;
+           }
         }
 
         /*


### PR DESCRIPTION
Gaps for split layout and never apply gaps if only App Launcher is available in that workspace.

**PS: This should be applied before PR #352** 