### PR TITLE
Improvements for removing MsWindows and launching apps on Wayland

### DIFF
--- a/src/layout/msWorkspace/msWindow.js
+++ b/src/layout/msWorkspace/msWindow.js
@@ -649,6 +649,8 @@ var MsWindow = GObject.registerClass(
         }
 
         kill() {
+            // Disconnect all signals from TileableItem that uses MsWindow
+            // to avoid errors
             this.emit('disconnect-tileable');
             let dialogPromises = this.dialogs.map((dialog) => {
                 return new Promise((resolve) => {
@@ -679,7 +681,6 @@ var MsWindow = GObject.registerClass(
                 if (this._persistent) {
                     this.unsetWindow();
                 } else {
-                    log('*** material-shell.msWindow | d.id: ' + this.destroyId);
                     this._onDestroy();
                     delete this.metaWindow;
                     this.msWorkspace.removeMsWindow(this);

--- a/src/layout/msWorkspace/msWindow.js
+++ b/src/layout/msWorkspace/msWindow.js
@@ -22,6 +22,7 @@ var MsWindow = GObject.registerClass(
                 param_types: [GObject.TYPE_BOOLEAN],
             },
             request_new_meta_window: {},
+            'disconnect-tileable': {},
         },
     },
     class MsWindow extends Clutter.Actor {
@@ -648,6 +649,7 @@ var MsWindow = GObject.registerClass(
         }
 
         kill() {
+            this.emit('disconnect-tileable');
             let dialogPromises = this.dialogs.map((dialog) => {
                 return new Promise((resolve) => {
                     delete dialog.metaWindow.msWindow;
@@ -677,10 +679,10 @@ var MsWindow = GObject.registerClass(
                 if (this._persistent) {
                     this.unsetWindow();
                 } else {
-                    delete this.metaWindow;
+                    log('*** material-shell.msWindow | d.id: ' + this.destroyId);
                     this._onDestroy();
+                    delete this.metaWindow;
                     this.msWorkspace.removeMsWindow(this);
-                    if (this.destroyId) this.disconnect(this.destroyId);
                     this.destroy();
                 }
             });
@@ -738,6 +740,7 @@ var MsWindow = GObject.registerClass(
         }
 
         _onDestroy() {
+            if (this.destroyId) this.disconnect(this.destroyId);
             this.unregisterOnMetaWindowSignals();
         }
     }

--- a/src/manager/msManager.js
+++ b/src/manager/msManager.js
@@ -12,6 +12,7 @@ var MsManager = class MsManager {
     observe(subject, property, callback) {
         let signal = {
             from: subject,
+            prop: property,
             id: subject.connect(property, callback),
         };
         this.signals.push(signal);
@@ -24,9 +25,28 @@ var MsManager = class MsManager {
             subject.disconnect(signal.id);
         };
     }
+
+    destroyItem(subject) {
+        this.signals
+            .filter((signal) => signal.from === subject)
+            .forEach((signal) => {
+                if (signal.from && signal.id) {
+                    log('*** material-shell.msManager | i.prop: ' + signal.prop);
+                    try {
+                        signal.from.disconnect(signal.id);
+                        this.signals.splice(this.signals.indexOf(signal), 1);
+                    } catch {
+                        log(`Failed to disconnect i.signal ${signal.id}`);
+                    }
+                }
+            });
+            log('*** material-shell.msManager | i.length: ' + this.signals.length);
+    }
+
     destroy() {
         this.signals.forEach((signal) => {
-            if (signal.from) {
+            if (signal.from && signal.id) {
+                log('*** material-shell.msManager | d.prop: ' + signal.prop);
                 try {
                     signal.from.disconnect(signal.id);
                 } catch (error) {
@@ -40,6 +60,7 @@ var MsManager = class MsManager {
                 }
             }
         });
+        log('*** material-shell.msManager | d.length: ' + this.signals.length);
     }
 };
 Signals.addSignalMethods(MsManager.prototype);

--- a/src/manager/msManager.js
+++ b/src/manager/msManager.js
@@ -12,7 +12,6 @@ var MsManager = class MsManager {
     observe(subject, property, callback) {
         let signal = {
             from: subject,
-            prop: property,
             id: subject.connect(property, callback),
         };
         this.signals.push(signal);
@@ -26,41 +25,33 @@ var MsManager = class MsManager {
         };
     }
 
-    disconnectItem(subject) {
+    destroy(subject) {
         this.signals
-            .filter((signal) => signal.from === subject)
+            .filter((signal) => {
+                if (subject) return signal.from === subject;
+                else return true;
+            })
             .forEach((signal) => {
-                if (signal.from && signal.id) {
-                    log('*** material-shell.msManager | i.prop: ' + signal.prop);
+                if (signal.from) {
                     try {
                         signal.from.disconnect(signal.id);
-                        this.signals.splice(this.signals.indexOf(signal), 1);
-                    } catch {
-                        log(`Failed to disconnect i.signal ${signal.id}`);
+                        if (subject) {
+                            this.signals.splice(
+                                this.signals.indexOf(signal),
+                                1
+                            );
+                        }
+                    } catch (error) {
+                        Me.log(
+                            `Failed to disconnect signal ${signal.id} from ${
+                                signal.from
+                            } ${
+                                signal.from.constructor.name
+                            } ${signal.from.toString()}  `
+                        );
                     }
                 }
             });
-            log('*** material-shell.msManager | i.length: ' + this.signals.length);
-    }
-
-    destroy() {
-        this.signals.forEach((signal) => {
-            if (signal.from && signal.id) {
-                log('*** material-shell.msManager | d.prop: ' + signal.prop);
-                try {
-                    signal.from.disconnect(signal.id);
-                } catch (error) {
-                    Me.log(
-                        `Failed to disconnect signal ${signal.id} from ${
-                            signal.from
-                        } ${
-                            signal.from.constructor.name
-                        } ${signal.from.toString()}  `
-                    );
-                }
-            }
-        });
-        log('*** material-shell.msManager | d.length: ' + this.signals.length);
     }
 };
 Signals.addSignalMethods(MsManager.prototype);

--- a/src/manager/msManager.js
+++ b/src/manager/msManager.js
@@ -25,33 +25,42 @@ var MsManager = class MsManager {
         };
     }
 
-    destroy(subject) {
-        this.signals
-            .filter((signal) => {
-                if (subject) return signal.from === subject;
-                else return true;
-            })
-            .forEach((signal) => {
-                if (signal.from) {
+    destroy() {
+        this.signals.forEach((signal) => {
+            if (signal.from) {
+                try {
+                    signal.from.disconnect(signal.id);
+                } catch (error) {
+                    Me.log(
+                        `Failed to disconnect signal ${signal.id} from ${
+                            signal.from
+                        } ${
+                            signal.from.constructor.name
+                        } ${signal.from.toString()}  `
+                    );
+                }
+            }
+        });
+    }
+
+    removeAll(subject) {
+        for (let i = this.signals.length ; i--;) {
+            if (this.signals[i].from == subject) {
+                let id = this.signals[i].id;
+                this.signals.splice(i, 1);
+                if (id) {
                     try {
-                        signal.from.disconnect(signal.id);
-                        if (subject) {
-                            this.signals.splice(
-                                this.signals.indexOf(signal),
-                                1
-                            );
-                        }
-                    } catch (error) {
+                        subject.disconnect(id);
+                    } catch (e) {
                         Me.log(
-                            `Failed to disconnect signal ${signal.id} from ${
-                                signal.from
-                            } ${
-                                signal.from.constructor.name
-                            } ${signal.from.toString()}  `
+                            `Failed to disconnect signal ${id} (${
+                                subject.constructor.name
+                            })`
                         );
                     }
                 }
-            });
+            }
+        }
     }
 };
 Signals.addSignalMethods(MsManager.prototype);

--- a/src/manager/msManager.js
+++ b/src/manager/msManager.js
@@ -26,7 +26,7 @@ var MsManager = class MsManager {
         };
     }
 
-    destroyItem(subject) {
+    disconnectItem(subject) {
         this.signals
             .filter((signal) => signal.from === subject)
             .forEach((signal) => {

--- a/src/manager/msWindowManager.js
+++ b/src/manager/msWindowManager.js
@@ -10,8 +10,8 @@ const { MsDndManager } = Me.imports.src.manager.msDndManager;
 const { getSettings } = Me.imports.src.utils.settings;
 
 const isWayland = GLib.getenv('XDG_SESSION_TYPE').toLowerCase() === 'wayland';
-const MAX_TIME_FIND = 2000 + ((isWayland ? 1 : 0) * 1000);
-const MAX_TIME_WAIT = 5000 + ((isWayland ? 1 : 0) * 1000);
+const MAX_TIME_FIND = 2000 + ((isWayland ? 2 : 0) * 1000);
+const MAX_TIME_WAIT = 5000 + ((isWayland ? 2 : 0) * 1000);
 
 /* exported MsWindowManager */
 var MsWindowManager = class MsWindowManager extends MsManager {

--- a/src/manager/msWindowManager.js
+++ b/src/manager/msWindowManager.js
@@ -13,6 +13,7 @@ const { getSettings } = Me.imports.src.utils.settings;
 const isWayland = GLib.getenv('XDG_SESSION_TYPE').toLowerCase() === 'wayland';
 const MAX_TIME_FIND = 2000 + ((isWayland ? 2 : 0) * 1000);
 const MAX_TIME_WAIT = 5000 + ((isWayland ? 2 : 0) * 1000);
+const TIME_CHECK = 100 + ((isWayland ? 1 : 0) * 100);
 
 /* exported MsWindowManager */
 var MsWindowManager = class MsWindowManager extends MsManager {
@@ -335,7 +336,7 @@ var MsWindowManager = class MsWindowManager extends MsManager {
         ) {
             if (this.checkInProgress) return;
             this.checkInProgress = true;
-            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, () => {
+            GLib.timeout_add(GLib.PRIORITY_DEFAULT, TIME_CHECK, () => {
                 this.checkInProgress = false;
                 this.checkWindowsForAssignations();
             });

--- a/src/manager/msWindowManager.js
+++ b/src/manager/msWindowManager.js
@@ -9,6 +9,7 @@ const { MsWindow } = Me.imports.src.layout.msWorkspace.msWindow;
 const { MsDndManager } = Me.imports.src.manager.msDndManager;
 const { getSettings } = Me.imports.src.utils.settings;
 
+// Wayland takes much longer to display new windows, so the way is increased
 const isWayland = GLib.getenv('XDG_SESSION_TYPE').toLowerCase() === 'wayland';
 const MAX_TIME_FIND = 2000 + ((isWayland ? 2 : 0) * 1000);
 const MAX_TIME_WAIT = 5000 + ((isWayland ? 2 : 0) * 1000);
@@ -182,7 +183,6 @@ var MsWindowManager = class MsWindowManager extends MsManager {
 
     checkWindowsForAssignations() {
         const timestamp = Date.now();
-        log('*** material-shell.msWindowManager | check: ' + timestamp);
 
         // For every waiting Window we do
         this.metaWindowWaitingForAssignationList.forEach(
@@ -190,7 +190,6 @@ var MsWindowManager = class MsWindowManager extends MsManager {
                 let app = this.windowTracker.get_window_app(
                     waitingMetaWindow.metaWindow
                 );
-                log('*** material-shell.msWindowManager | a.name: ' + app.get_name());
                 let msWindowFound = null;
                 // If window is dialog try t0 find his parent
                 if (this.isMetaWindowDialog(waitingMetaWindow.metaWindow)) {
@@ -210,9 +209,7 @@ var MsWindowManager = class MsWindowManager extends MsManager {
                             }
                         );
                         //We take the msWindow focused the last
-                        log('*** material-shell.msWindowManager | msWindowFound: ' + msWindowFound);
                         sameAppMsWindowList.forEach((msWindow) => {
-                            log('*** material-shell.msWindowManager | w.title: ' + msWindow.title);
                             if (
                                 !msWindowFound ||
                                 msWindowFound.metaWindow.get_user_time() <
@@ -224,13 +221,11 @@ var MsWindowManager = class MsWindowManager extends MsManager {
                     }
                 }
 
-                log('*** material-shell.msWindowManager | found1: ' + msWindowFound);
                 if (!msWindowFound) {
                     // First check among the msWindow waiting for an App to be opened
                     this.msWindowWaitingForMetaWindowList.some(
                         (waitingMsWindow) => {
                             waitingMsWindow.checked = true;
-                            log('*** material-shell.msWindowManager | w.id: ' + waitingMsWindow.msWindow.app.get_id() + ' a.id: ' + app.get_id());
                             if (
                                 app &&
                                 waitingMsWindow.msWindow.app.get_id() ===
@@ -253,7 +248,6 @@ var MsWindowManager = class MsWindowManager extends MsManager {
                     return;
                 }
 
-                log('*** material-shell.msWindowManager | app: ' + app.get_name());
                 if (!msWindowFound) {
                     //Then check among empty msWindows
                     const emptyMsWindowListOfApp = this.msWindowList.filter(
@@ -279,7 +273,6 @@ var MsWindowManager = class MsWindowManager extends MsManager {
                     }
                 }
 
-                log('*** material-shell.msWindowManager | found2: ' + msWindowFound);
                 if (msWindowFound) {
                     if (this.isMetaWindowDialog(waitingMetaWindow.metaWindow)) {
                         msWindowFound.addDialog(waitingMetaWindow.metaWindow);
@@ -287,10 +280,10 @@ var MsWindowManager = class MsWindowManager extends MsManager {
                         msWindowFound.setWindow(waitingMetaWindow.metaWindow);
                     }
                 } else {
+                    // This is not needed
                     // let app = this.windowTracker.get_window_app(
                     //     waitingMetaWindow.metaWindow
                     // );
-                    log(`*** material-shell.msWindowManager | t1: ${timestamp - waitingMetaWindow.timestamp}`);
                     if (
                         (waitingMetaWindow.metaWindow.firstFrameDrawn &&
                             !app.is_window_backed()) ||
@@ -320,13 +313,11 @@ var MsWindowManager = class MsWindowManager extends MsManager {
 
         // Remove MsWindow waiting for too much time. We probably missed the window awaited.
         this.msWindowWaitingForMetaWindowList.forEach((waitingMsWindow) => {
-            log(`*** material-shell.msWindowManager | t2: ${timestamp - waitingMsWindow.timestamp}`);
             if (
                 (waitingMsWindow.checked &&
                     timestamp - waitingMsWindow.timestamp > MAX_TIME_FIND) ||
                 timestamp - waitingMsWindow.timestamp > MAX_TIME_WAIT
             ) {
-                log('*** material-shell.msWindowManager | checked: ' + waitingMsWindow.checked);
                 waitingMsWindow.msWindow.kill();
                 this.msWindowWaitingForMetaWindowList.splice(
                     this.msWindowWaitingForMetaWindowList.indexOf(
@@ -342,11 +333,9 @@ var MsWindowManager = class MsWindowManager extends MsManager {
             this.metaWindowWaitingForAssignationList.length ||
             this.msWindowWaitingForMetaWindowList.length
         ) {
-            log('*** material-shell.msWindowManager | checkInProgress: ' + this.checkInProgress);
             if (this.checkInProgress) return;
             this.checkInProgress = true;
             GLib.timeout_add(GLib.PRIORITY_DEFAULT, 200, () => {
-                log('*** material-shell.msWindowManager | timeout');
                 this.checkInProgress = false;
                 this.checkWindowsForAssignations();
             });
@@ -379,19 +368,6 @@ var MsWindowManager = class MsWindowManager extends MsManager {
         let workspaceIndex = Me.msWorkspaceManager.primaryMsWorkspaces.indexOf(
             msWindow.msWorkspace
         );
-        // const app = msWindow.app;
-        // if (isWayland && app.get_state() === Shell.AppState.STOPPED) {
-        //     const useGPU =
-        //         app.get_app_info().get_boolean('PrefersNonDefaultGPU') ||
-        //         app.get_app_info().get_boolean('X-KDE-RunOnDiscreteGpu');
-        //     log('*** material-shell.msWindowManager | launch: ' +
-        //         app.get_name() + ' useGPU: ' + useGPU);
-        //     app.launch(0, workspaceIndex, useGPU);
-        // } else {
-        //     log('*** material-shell.msWindowManager | open: ' + msWindow.title);
-        //     app.open_new_window(workspaceIndex);
-        // }
-        log('*** material-shell.msWindowManager | open: ' + msWindow.title + ' ***');
         msWindow.app.open_new_window(workspaceIndex);
     }
 

--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -633,7 +633,7 @@ let TileableItem = GObject.registerClass(
         }
 
         disconnectTileable() {
-            this.signalManager.destroyItem(this.tileable);
+            this.signalManager.disconnectItem(this.tileable);
         }
 
         setStyle() {

--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -350,7 +350,7 @@ var TaskBar = GObject.registerClass(
     }
 );
 
-let TaskBarItem = GObject.registerClass(
+var TaskBarItem = GObject.registerClass(
     {
         Signals: {
             'drag-dropped': {},

--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -100,6 +100,9 @@ var TaskBar = GObject.registerClass(
                         item.connect('close-clicked', (_) => {
                             tileable.kill();
                         });
+                        item.tileable.connect('disconnect-tileable', (_) => {
+                            item.disconnectTileable();
+                        });
 
                         item._draggable.connect('drag-begin', () => {
                             const initialIndex = this.msWorkspace.tileableList.indexOf(
@@ -627,6 +630,10 @@ let TileableItem = GObject.registerClass(
             this.container.add_child(this.startIconContainer);
             this.container.add_child(this.title);
             this.container.add_child(this.endIconContainer);
+        }
+
+        disconnectTileable() {
+            this.signalManager.destroyItem(this.tileable);
         }
 
         setStyle() {

--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -633,7 +633,7 @@ let TileableItem = GObject.registerClass(
         }
 
         disconnectTileable() {
-            this.signalManager.destroy(this.tileable);
+            this.signalManager.removeAll(this.tileable);
         }
 
         setStyle() {

--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -633,7 +633,7 @@ let TileableItem = GObject.registerClass(
         }
 
         disconnectTileable() {
-            this.signalManager.disconnectItem(this.tileable);
+            this.signalManager.destroy(this.tileable);
         }
 
         setStyle() {


### PR DESCRIPTION
When a TileableItems was removed, it would kill the related MsWindow first without disconnecting the signals used in the TileableItem, causing many errors. This commit also added some tweaks in timing to make launching apps on Wayland much more reliable. I haven't seen JS ERROR in gnome-shell log anymore since these commits, even when suspending or disabling/enabling the extension.

Fix #250 