### PR TITLE
In normal mode, apply gaps

### DIFF
--- a/src/layout/msWorkspace/tilingLayouts/maximize.js
+++ b/src/layout/msWorkspace/tilingLayouts/maximize.js
@@ -91,10 +91,12 @@ var MaximizeLayout = GObject.registerClass(
         }
 
         tileTileable(tileable, box) {
-            tileable.x = box.x1;
-            tileable.y = box.y1;
-            tileable.width = box.get_width();
-            tileable.height = box.get_height();
+            let { x, y, width, height } = this.applyGaps(box.x1, box.y1, box.get_width(), box.get_height());
+
+            tileable.x = x;
+            tileable.y = y;
+            tileable.width = width;
+            tileable.height = height;
         }
 
         /*


### PR DESCRIPTION
In option, I defined gaps for my windows.

In normal mode (one window uses the whole space), the gaps does not apply, and switching to another layout disturbs the user (actually me here) because the gaps apply