### PR TITLE
Improve theme reload, avoid empty theme flash

### DIFF
--- a/src/manager/msThemeManager.js
+++ b/src/manager/msThemeManager.js
@@ -4,6 +4,7 @@ const Main = imports.ui.main;
 
 /** Extension imports */
 const Me = imports.misc.extensionUtils.getCurrentExtension();
+const { ShellVersionMatch } = Me.imports.src.utils.compatibility;
 const { getSettings } = Me.imports.src.utils.settings;
 const { MsManager } = Me.imports.src.manager.msManager;
 
@@ -202,7 +203,12 @@ var MsThemeManager = class MsThemeManager extends MsManager {
 
     async regenerateStylesheet() {
         this.unloadStylesheet();
-        // this.themeContext.set_theme(new St.Theme());
+
+        if (ShellVersionMatch('3.34')) {
+            //TODO The new code may prevent crashes on 3.34 without this, needs testing
+            // This loads an empty theme, cleaning all nodes but causes top panel flash
+            this.themeContext.set_theme(new St.Theme());
+        }
         await this.buildThemeStylesheetToFile(this.themeFile);
         this.theme.load_stylesheet(this.themeFile);
         GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {

--- a/src/manager/msThemeManager.js
+++ b/src/manager/msThemeManager.js
@@ -1,5 +1,6 @@
 /** Gnome libs imports */
 const { GLib, Gio, St } = imports.gi;
+const Main = imports.ui.main;
 
 /** Extension imports */
 const Me = imports.misc.extensionUtils.getCurrentExtension();
@@ -200,11 +201,16 @@ var MsThemeManager = class MsThemeManager extends MsManager {
     }
 
     async regenerateStylesheet() {
-        await this.buildThemeStylesheetToFile(this.themeFile);
         this.unloadStylesheet();
+        // this.themeContext.set_theme(new St.Theme());
+        await this.buildThemeStylesheetToFile(this.themeFile);
         this.theme.load_stylesheet(this.themeFile);
-        this.themeContext.set_theme(new St.Theme());
-        this.themeContext.set_theme(this.theme);
+        GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+            this.themeContext.set_theme(this.theme);
+            Main.reloadThemeResource();
+            Main.loadTheme();
+            return GLib.SOURCE_REMOVE;
+        });
     }
 
     unloadStylesheet() {


### PR DESCRIPTION
This also prevents crashes on Wayland when reloading the theme.