### PR TITLE
Overall panel icons improvements and small fixes

### DIFF
--- a/src/layout/msWorkspace/horizontalPanel.js
+++ b/src/layout/msWorkspace/horizontalPanel.js
@@ -51,14 +51,6 @@ var HorizontalPanel = GObject.registerClass(
             }
         }
 
-        buildIcon(height) {
-            this.iconSize = height;
-            this.tilingIcon.set_icon_size(
-                Me.msThemeManager.getPanelSizeNotScaled() / 2
-            );
-            this.queue_relayout();
-        }
-
         createClock() {
             this.clockLabel = new St.Label({
                 style_class: 'clock-label',
@@ -111,10 +103,13 @@ var HorizontalPanel = GObject.registerClass(
         }
 
         vfunc_allocate(box, flags) {
-            SetAllocation(this, box, flags);
-            if (!this.tilingIcon || this.iconSize != box.get_height()) {
-                this.buildIcon(box.get_height());
+            if (
+                !this.tilingIcon ||
+                this.tilingIcon.get_icon_size() != box.get_height() / 2
+            ) {
+                this.tilingIcon.set_icon_size(box.get_height() / 2);
             }
+            SetAllocation(this, box, flags);
             let themeNode = this.get_theme_node();
             const contentBox = themeNode.get_content_box(box);
             let clockWidth = this.clockBin

--- a/src/layout/msWorkspace/horizontalPanel.js
+++ b/src/layout/msWorkspace/horizontalPanel.js
@@ -49,12 +49,14 @@ var HorizontalPanel = GObject.registerClass(
             if (Me.msThemeManager.clockHorizontal) {
                 this.createClock();
             }
-            Me.msThemeManager.connect('panel-size-changed', () => {
-                this.tilingIcon.set_icon_size(
-                    Me.msThemeManager.getPanelSizeNotScaled() / 2
-                );
-                this.queue_relayout();
-            });
+        }
+
+        buildIcon(height) {
+            this.iconSize = height;
+            this.tilingIcon.set_icon_size(
+                Me.msThemeManager.getPanelSizeNotScaled() / 2
+            );
+            this.queue_relayout();
         }
 
         createClock() {
@@ -110,6 +112,9 @@ var HorizontalPanel = GObject.registerClass(
 
         vfunc_allocate(box, flags) {
             SetAllocation(this, box, flags);
+            if (!this.tilingIcon || this.iconSize != box.get_height()) {
+                this.buildIcon(box.get_height());
+            }
             let themeNode = this.get_theme_node();
             const contentBox = themeNode.get_content_box(box);
             let clockWidth = this.clockBin

--- a/src/layout/msWorkspace/horizontalPanel.js
+++ b/src/layout/msWorkspace/horizontalPanel.js
@@ -104,7 +104,7 @@ var HorizontalPanel = GObject.registerClass(
 
         vfunc_allocate(box, flags) {
             if (
-                !this.tilingIcon ||
+                this.tilingIcon &&
                 this.tilingIcon.get_icon_size() != box.get_height() / 2
             ) {
                 this.tilingIcon.set_icon_size(box.get_height() / 2);

--- a/src/layout/msWorkspace/tilingLayouts/split.js
+++ b/src/layout/msWorkspace/tilingLayouts/split.js
@@ -50,8 +50,8 @@ var SplitLayout = GObject.registerClass(
             );
         }
 
-        onTileableListChanged(msWorkspace, newWindows, oldWindows) {
-            super.onTileableListChanged(msWorkspace, newWindows, oldWindows);
+        onTileableListChanged(newWindows, oldWindows) {
+            super.onTileableListChanged(newWindows, oldWindows);
             this.updateActiveTileableListFromFocused();
             this.refreshVisibleActors();
         }

--- a/src/layout/verticalPanel/statusArea.js
+++ b/src/layout/verticalPanel/statusArea.js
@@ -199,6 +199,11 @@ var MsDateMenuBox = GObject.registerClass(
                 layout_manager: new Clutter.BinLayout(),
             });
             this.dateMenu = dateMenu;
+             // Before 3.36 _indicator was just a class with an actor as property
+            this.indicatorActor =
+                this.dateMenu._indicator instanceof Clutter.Actor
+                    ? this.dateMenu._indicator
+                    : this.dateMenu._indicator.actor;
 
             this._wallClock = new GnomeDesktop.WallClock({ time_only: true });
 
@@ -244,8 +249,7 @@ var MsDateMenuBox = GObject.registerClass(
                 this.updateClock.bind(this)
             );
 
-            // Before 3.36 _indicator was just a class with an actor as property
-            (dateMenu._indicator.actor || dateMenu._indicator).connect(
+            this.indicatorActor.connect(
                 'notify::visible',
                 this.updateVisibility.bind(this)
             );
@@ -274,9 +278,7 @@ var MsDateMenuBox = GObject.registerClass(
         }
 
         updateVisibility() {
-            let indicatorActor =
-                this.dateMenu._indicator.actor || this.dateMenu._indicator;
-            if (indicatorActor.visible) {
+            if (this.indicatorActor.visible) {
                 if (Me.msThemeManager.clockHorizontal) {
                     this.notificationIcon.hide();
                     this.notificationIconRing.show();

--- a/src/layout/verticalPanel/workspaceList.js
+++ b/src/layout/verticalPanel/workspaceList.js
@@ -637,6 +637,9 @@ var WorkspaceButtonIcon = GObject.registerClass(
             Me.msThemeManager.connect('panel-icon-style-changed', () => {
                 this.buildIcons();
             });
+            Me.msThemeManager.connect('panel-size-changed', () => {
+                this.buildIcons();
+            });
         }
 
         buildIcons() {

--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -641,17 +641,13 @@ let TileableItem = GObject.registerClass(
 
         buildIcon(height) {
             if (this.icon) this.icon.destroy();
-            this.referenceSize = height;
-            this.icon = this.app.create_icon_texture(this.referenceSize / 2);
+            this.lastHeight = height;
+            this.icon = this.app.create_icon_texture(height / 2);
             this.icon.style_class = 'app-icon';
-            this.icon.set_size(this.referenceSize / 2, this.referenceSize / 2);
+            this.icon.set_size(height / 2, height / 2);
             this.startIconContainer.set_child(this.icon);
-            this.persistentIcon.set_icon_size(
-                Me.msThemeManager.getPanelSizeNotScaled() / 2
-            );
-            this.closeIcon.set_icon_size(
-                Me.msThemeManager.getPanelSizeNotScaled() / 2
-            );
+            this.persistentIcon.set_icon_size(height / 2);
+            this.closeIcon.set_icon_size(height / 2);
             this.queue_relayout();
         }
 
@@ -681,7 +677,7 @@ let TileableItem = GObject.registerClass(
             }
         }
         vfunc_allocate(box, flags) {
-            if (!this.icon || this.referenceSize != box.get_height()) {
+            if (!this.icon || this.lastHeight != box.get_height()) {
                 this.buildIcon(box.get_height());
             }
             super.vfunc_allocate(box, flags);
@@ -719,7 +715,7 @@ let IconTaskBarItem = GObject.registerClass(
 
         vfunc_allocate(box, flags) {
             if (
-                !this.icon ||
+                this.icon &&
                 this.icon.get_icon_size() != box.get_height() / 2
             ) {
                 this.icon.set_icon_size(box.get_height() / 2);

--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -603,7 +603,7 @@ let TileableItem = GObject.registerClass(
                 gicon: Gio.icon_new_for_string(
                     `${Me.path}/assets/icons/close-symbolic.svg`
                 ),
-            })
+            });
             this.closeButton = new St.Button({
                 style_class: 'task-close-button',
                 child: this.closeIcon,
@@ -641,10 +641,10 @@ let TileableItem = GObject.registerClass(
 
         buildIcon(height) {
             if (this.icon) this.icon.destroy();
-            this.iconSize = height;
-            this.icon = this.app.create_icon_texture(this.iconSize / 2);
+            this.referenceSize = height;
+            this.icon = this.app.create_icon_texture(this.referenceSize / 2);
             this.icon.style_class = 'app-icon';
-            this.icon.set_size(this.iconSize / 2, this.iconSize / 2);
+            this.icon.set_size(this.referenceSize / 2, this.referenceSize / 2);
             this.startIconContainer.set_child(this.icon);
             this.persistentIcon.set_icon_size(
                 Me.msThemeManager.getPanelSizeNotScaled() / 2
@@ -681,7 +681,7 @@ let TileableItem = GObject.registerClass(
             }
         }
         vfunc_allocate(box, flags) {
-            if (!this.icon || this.iconSize != box.get_height()) {
+            if (!this.icon || this.referenceSize != box.get_height()) {
                 this.buildIcon(box.get_height());
             }
             super.vfunc_allocate(box, flags);
@@ -709,13 +709,7 @@ let IconTaskBarItem = GObject.registerClass(
             });
             this.container.set_child(this.icon);
         }
-        buildIcon(height) {
-            this.iconSize = height;
-            this.icon.set_icon_size(
-                Me.msThemeManager.getPanelSizeNotScaled() / 2
-            );
-            this.queue_relayout();
-        }
+
         /**
          * Just the panel width
          */
@@ -724,8 +718,11 @@ let IconTaskBarItem = GObject.registerClass(
         }
 
         vfunc_allocate(box, flags) {
-            if (!this.icon || this.iconSize != box.get_height()) {
-                this.buildIcon(box.get_height());
+            if (
+                !this.icon ||
+                this.icon.get_icon_size() != box.get_height() / 2
+            ) {
+                this.icon.set_icon_size(box.get_height() / 2);
             }
             super.vfunc_allocate(box, flags);
         }

--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -648,7 +648,6 @@ let TileableItem = GObject.registerClass(
             this.startIconContainer.set_child(this.icon);
             this.persistentIcon.set_icon_size(height / 2);
             this.closeIcon.set_icon_size(height / 2);
-            this.queue_relayout();
         }
 
         setActive(active) {

--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -528,7 +528,7 @@ let TileableItem = GObject.registerClass(
                 `Make this fully persistent`,
                 () => {
                     this.tileable.persistent = true;
-                    this.endIconContainer.set_child(this.peristentIcon);
+                    this.endIconContainer.set_child(this.persistentIcon);
                     this.makePersistentAction.hide();
                     this.unmakePersistentAction.show();
                 },
@@ -612,14 +612,14 @@ let TileableItem = GObject.registerClass(
                 this.emit('close-clicked');
             });
 
-            this.peristentIcon = new St.Icon({
+            this.persistentIcon = new St.Icon({
                 style_class: 'task-small-icon',
                 gicon: Gio.icon_new_for_string(
                     `${Me.path}/assets/icons/pin-symbolic.svg`
                 ),
             });
             if (this.tileable._persistent) {
-                this.endIconContainer.set_child(this.peristentIcon);
+                this.endIconContainer.set_child(this.persistentIcon);
             } else {
                 this.endIconContainer.set_child(this.closeButton);
             }

--- a/src/widget/taskBar.js
+++ b/src/widget/taskBar.js
@@ -598,16 +598,16 @@ let TileableItem = GObject.registerClass(
             this.setStyle();
             this.connect('destroy', this._onDestroy.bind(this));
             // CLOSE BUTTON
+            this.closeIcon = new St.Icon({
+                style_class: 'task-small-icon',
+                gicon: Gio.icon_new_for_string(
+                    `${Me.path}/assets/icons/close-symbolic.svg`
+                ),
+            })
             this.closeButton = new St.Button({
                 style_class: 'task-close-button',
-                child: new St.Icon({
-                    style_class: 'task-small-icon',
-                    gicon: Gio.icon_new_for_string(
-                        `${Me.path}/assets/icons/close-symbolic.svg`
-                    ),
-                }),
+                child: this.closeIcon,
             });
-
             this.closeButton.connect('clicked', () => {
                 this.emit('close-clicked');
             });
@@ -646,6 +646,12 @@ let TileableItem = GObject.registerClass(
             this.icon.style_class = 'app-icon';
             this.icon.set_size(this.iconSize / 2, this.iconSize / 2);
             this.startIconContainer.set_child(this.icon);
+            this.persistentIcon.set_icon_size(
+                Me.msThemeManager.getPanelSizeNotScaled() / 2
+            );
+            this.closeIcon.set_icon_size(
+                Me.msThemeManager.getPanelSizeNotScaled() / 2
+            );
             this.queue_relayout();
         }
 
@@ -699,14 +705,29 @@ let IconTaskBarItem = GObject.registerClass(
             this.icon = new St.Icon({
                 gicon,
                 style_class: 'app-icon',
+                icon_size: Me.msThemeManager.getPanelSizeNotScaled() / 2,
             });
             this.container.set_child(this.icon);
+        }
+        buildIcon(height) {
+            this.iconSize = height;
+            this.icon.set_icon_size(
+                Me.msThemeManager.getPanelSizeNotScaled() / 2
+            );
+            this.queue_relayout();
         }
         /**
          * Just the panel width
          */
         vfunc_get_preferred_width(_forHeight) {
             return [_forHeight, _forHeight];
+        }
+
+        vfunc_allocate(box, flags) {
+            if (!this.icon || this.iconSize != box.get_height()) {
+                this.buildIcon(box.get_height());
+            }
+            super.vfunc_allocate(box, flags);
         }
     }
 );


### PR DESCRIPTION
- Fix 'onTileableListChanged' in Split layout https://github.com/material-shell/material-shell/pull/407/commits/e5a7ef27af972e18add7782ad1d395c599d58c1f
- Fixed typo (peristentIcon) https://github.com/material-shell/material-shell/pull/407/commits/90e75976f05c40626f5c835f5245ea1db3dcc523
- Improved icon size consistency https://github.com/material-shell/material-shell/pull/407/commits/b64d975ebf6f7fc8e0998dbf506e654a6ac1d0d9
- Fixed disappearing layout icon when changing panel size https://github.com/material-shell/material-shell/pull/407/commits/b64d975ebf6f7fc8e0998dbf506e654a6ac1d0d9
- Icon sizes are updated when panel size is changed https://github.com/material-shell/material-shell/pull/407/commits/b64d975ebf6f7fc8e0998dbf506e654a6ac1d0d9
- Fix "_indicator.actor is deprecated" message for Gnome Shell 3.36 while still compatible with 3.34 https://github.com/material-shell/material-shell/pull/407/commits/bd20a0c27aaa6e90f90e95e3791d09c9f36ec1eb