### PR TITLE
Added section for non-hotkey actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Some hotkeys might already be used by GNOME Shell - please check your keybinding
 * `Super+Space` Cycle the tiling layout of the current workspace.
 * `Super+Escape` Toggle the UI of Material-shell, like a Zen mode.
 
+## Other Actions
+* Middle-click on a workspace closes the workspace and all applications in it.
+* Right-click on any workspace to change the icon settings for the workspaces.
+
 # Installation
 
 #### Get it in two clicks


### PR DESCRIPTION
The comment in https://github.com/material-shell/material-shell/issues/225 taught me I can middle click to close a workspace, this should be documented somewhere. Right under the hotkey section seems like a good place to me.