### PR TITLE
Disable broken horizontal/launcher clocks

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -49,8 +49,8 @@ function buildPrefsWidget() {
     if (!ShellVersionMatch('3.34')) {
         theme.addSetting('blur-background', WidgetType.BOOLEAN);
     }
-    theme.addSetting('clock-horizontal', WidgetType.BOOLEAN);
-    theme.addSetting('clock-app-launcher', WidgetType.BOOLEAN);
+    // theme.addSetting('clock-horizontal', WidgetType.BOOLEAN);
+    // theme.addSetting('clock-app-launcher', WidgetType.BOOLEAN);
 
     settingsTab.addCategory(theme);
 

--- a/src/manager/msThemeManager.js
+++ b/src/manager/msThemeManager.js
@@ -123,11 +123,11 @@ var MsThemeManager = class MsThemeManager extends MsManager {
     }
 
     get clockHorizontal() {
-        return this.themeSettings.get_boolean('clock-horizontal');
+        return false; // return this.themeSettings.get_boolean('clock-horizontal');
     }
 
     get clockAppLauncher() {
-        return this.themeSettings.get_boolean('clock-app-launcher');
+        return false; // return this.themeSettings.get_boolean('clock-app-launcher');
     }
 
     getPanelSize(monitorIndex) {


### PR DESCRIPTION
Disable the clocks for now due to issue #458. The views are not being updated and desync with the state, showing the wrong time.

It's better to show no time at all, than to show the wrong time. This change removes the options, leaving only the normal vertical clock that works fine.