### PR TITLE
Fix: trim excluded window class names on check

### DIFF
--- a/src/manager/msWindowManager.js
+++ b/src/manager/msWindowManager.js
@@ -337,6 +337,7 @@ var MsWindowManager = class MsWindowManager extends MsManager {
             getSettings('layouts')
                 .get_string('windows-excluded')
                 .split(',')
+                .map((item) => item.trim())
                 .indexOf(metaWindow.wm_class) > -1
         ) {
             return false;


### PR DESCRIPTION
Quality of life change in "Excluded windows".

Now WM should trim class names preventing failures when user type in something like `'Tilix, Gnome-calculator'` and can't figure out why Gnome-calculator window still tiles (cause WM searches for `' Gnome-calculator'`).

**Warning:** I haven't actually build and test this fix, but since it's pretty obvious and stupidly simple I find it hard to break something with this one line change.