### PR TITLE
Update to README.md -- added kb shortcuts, brief tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,30 +117,32 @@ This allow to **configure** the layouts **on the go** while using it.
 When opening a **new session** Material Shell will **restore every windows** previously present with a "**window placeholder** which allow you to reopen any of the previous window easily at the same spot you like to have them.
 
 
-#### Brief Tutorial 
-Learn the basics of Material Shell using the mouse and keyboard shortcuts.
+## Brief Tutorial
+Getting around using the mouse and keyboard shortcuts
 
 Setup
-1. For this tutorial, the first workspace will mimic traditional window behavior.
-2. Click on the tiling icon in the upper right corner. Click on 'Tweak available layout'.
-3. For this workspace, turn off all layout styles except floating. This window will be used to view this README.md file
-4. To open a second work space, click on the + on the left side of the screen, or use *`Super+s`
-5. Turn on the first 6 tiling choices on, e.g, maximize, split ... half vertical. Turn off the remaining, especially float.
-6. Click on the tiling icon again and select Split. Increase the number of layouts to 4.
-7. Use *`Super+x` to open the App Launcher and open 4 terminal windows. Once finished, there should be 4 vertical (Split) windows.
-8. Execute a command in each terminal instance so that they are are distinguishable from each other, e.g. ls, nano, ping --help, man ping.
-9. Cycle through the tiling layouts using Super+Spacebar. Notice that the tiling-layout icon updates to represent the current layout.
-10.Experiment with keyboard shortcuts below including moving the focus, moving a window, and resizing a window.
+1. The first workspace is used view this README.md file. The 2nd, 3rd,.. 10th will be used for Material-Shell practice.
+2. In the first workspace, click on the tiling icon in the upper right corner. Click on `Tweak available layout`.
+3. Turn off all layout styles except 'floating'. Floating layout  mimics traditional floating windows behaviors.
+4. To open a second work space, click on the `+` on the left side of the screen, or use `Super+s`
+5. Turn on the first 6 tiling choices on, e.g., `maximize, split ... half vertical`. Turn off the remaining, especially float.
+6. Click on the tiling icon again and select `Grid` Increase the number of layouts to `4`.
+7. Use *`Super+x` to bring forth the App Launcher and open 4 terminal windows. Once finished, there should be a grid of 4 windows.
+8. Execute a command in each terminal instance so that they are are distinguishable from each other, e.g. ls, nano, man ls, ping --help.
+
+Practice
+9. Cycle through the tiling layouts using `Super+Spacebar`. Notice that the tiling-layout icon updates to represent the current layout.
+10. Experiment with keyboard shortcuts below including opening applications in their own workspaces, moving the focus, moving a window, and resizing a window.
 
 Take note of the following:
-1. The workspace icons are located on the left side of the screen and the window panes are located at the top of the screen.
-2. When using a browser, the browser tabs are located below the window panes. They can be similar in appearance.
-3. There isn't a keyboard/mouse equivalent of Maximize window. Use the tiling layout icon or Super+spacebar to return to a max window.
+1. The workspace icons are located on the left side of the screen and the window panes (tabs) are located at the top of the screen.
+2. When using a browser, the browser tabs are located below the window panes. Browser tabs and window panes can be similar in appearance.
+3. There isn't a keyboard/mouse equivalent of `Maximize` window. Use the tiling layout icon or `Super+spacebar` to return to a maximized window.
 4. Tiling layout preferences are unique to the each  workspace (the preferences are not global setting for all workspaces).
-5. To mimic traditional windows behavior, use the float setting. Tiling is turned off for that window.
 
 ## Hotkeys
-Some hotkeys might already be used by GNOME Shell - please check your keybindings first.
+Material-Shell is often used in conjunction with Gnome keyboard-shortcuts, Firefox shortcuts, etc. 
+Note that some hotkeys might already be used by other applications - please check your keybindings first.
 
 #### Choosing tiling layout
 * `Super+Space` Cycle through the tiling options in the current workspace.
@@ -149,7 +151,7 @@ Some hotkeys might already be used by GNOME Shell - please check your keybinding
 * `Super+x` Open the App Launcher within a new window.
 * `Super+q` Kill the current focused window.
 
-#### Navigation -- moving the focus 
+#### Moving the focus aka Navigation
 ... window panes 
 * `Super+d` Focus on the next window pane, left to right.
 * `Super+a` Focus on the previous window pane, right to left.
@@ -192,10 +194,10 @@ Some hotkeys might already be used by GNOME Shell - please check your keybinding
 * `Super+[MouseDrag]` Move window around.
 
 #### Resize a window
-* `Ctrl+Super+left` Enlarge a window to the left.
-* `Ctrl+Super+up` Enlarge a window upward.
-* `Ctrl+Super+right`Enlarge an window to the  right.
-* `Ctrl+Super+down` Enlarge a window downward.
+* `Ctrl+Super+left` Increase width moving border to the left.
+* `Ctrl+Super+up` Increase height moving border upward.
+* `Ctrl+Super+right` Increase width moving border to the right.
+* `Ctrl+Super+down` Increase height moving border downward.
 
 
 #### Extra Hotkeys

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Setup
 7. Click on the tiling icon again and select `Split` from the list of layouts. Increase the number of layouts to `4`.
 8. Use `Super+x` to open App Launcher, and then open a terminal window. Do this 4 times. There should 4 (Split) windows on the desktop.
 9. Execute a command in each terminal instance so that the terminal windows are distinguishable from each other. For example, execute `ls, nano, man ls, htop` respectively.
-10. Use `Super+0` to open another workspace, and then open two applications, for example, an email client and Libre Writer.
-11. Use `Super+End` to open another workspace, and then open an image editor.
+10. Use `Super+0` to open another workspace, and open two applications, for example, an email client and Libre Writer.
+11. Use `Super+End` to open another workspace, and  open an image editor.
 
 Practice
 
@@ -251,9 +251,10 @@ gnome-extensions enable material-shell@papyelgringo
 * GTK and GNOME Shell theme: [Plata Theme](https://gitlab.com/tista500/plata-theme)
 * Icon theme: [Tela Icon Theme](https://github.com/vinceliuice/Tela-icon-theme)
 
-# Uninstallation (single-user) 😢
+# Uninstallation 😢
 We're sad to see you go. Before you uninstall, leave us some feedback by [opening an issue](https://github.com/material-shell/material-shell/issues/new/choose) - it will be very helpful in improving Material Shell.
 
+## Gnome extension or single-user
 1. Open `gnome-tweaks` and disable the `Material Shell` extension **OR** disable it using 
 ```bash
 gnome-extensions disable material-shell@papyelgringo
@@ -262,8 +263,8 @@ gnome-extensions disable material-shell@papyelgringo
 ```bash
 rm -rf ~/.local/share/gnome-shell/extensions/material-shell@papyelgringo
 ```
-#(multi-user or development)
-1. Remove via the appropriate package manager.
+## Package manager, multi-user, or development.
+Remove via the appropriate package manager.
 
 # History
 The project is based on my earlier work on [Material Awesome](https://github.com/PapyElGringo/material-awesome).

--- a/README.md
+++ b/README.md
@@ -116,34 +116,100 @@ This allow to **configure** the layouts **on the go** while using it.
 
 When opening a **new session** Material Shell will **restore every windows** previously present with a "**window placeholder** which allow you to reopen any of the previous window easily at the same spot you like to have them.
 
+
+#### Brief Tutorial 
+Learn the basics of Material Shell using the mouse and keyboard shortcuts.
+
+Setup
+1. For this tutorial, the first workspace will mimic traditional window behavior.
+2. Click on the tiling icon in the upper right corner. Click on 'Tweak available layout'.
+3. For this workspace, turn off all layout styles except floating. This window will be used to view this README.md file
+4. To open a second work space, click on the + on the left side of the screen, or use *`Super+s`
+5. Turn on the first 6 tiling choices on, e.g, maximize, split ... half vertical. Turn off the remaining, especially float.
+6. Click on the tiling icon again and select Split. Increase the number of layouts to 4.
+7. Use *`Super+x` to open the App Launcher and open 4 terminal windows. Once finished, there should be 4 vertical (Split) windows.
+8. Execute a command in each terminal instance so that they are are distinguishable from each other, e.g. ls, nano, ping --help, man ping.
+9. Cycle through the tiling layouts using Super+Spacebar. Notice that the tiling-layout icon updates to represent the current layout.
+10.Experiment with keyboard shortcuts below including moving the focus, moving a window, and resizing a window.
+
+Take note of the following:
+1. The workspace icons are located on the left side of the screen and the window panes are located at the top of the screen.
+2. When using a browser, the browser tabs are located below the window panes. They can be similar in appearance.
+3. There isn't a keyboard/mouse equivalent of Maximize window. Use the tiling layout icon or Super+spacebar to return to a max window.
+4. Tiling layout preferences are unique to the each  workspace (the preferences are not global setting for all workspaces).
+5. To mimic traditional windows behavior, use the float setting. Tiling is turned off for that window.
+
 ## Hotkeys
 Some hotkeys might already be used by GNOME Shell - please check your keybindings first.
-#### Desktop navigation
-* `Super+W` Navigate to the upper workspace/category.
-* `Super+S` Navigate to the lower workspace/category.
-* `Super+A` Focus the window at the left of the current window.
-* `Super+D` Focus the window at the right of the current window.
-* `Super+1`, `Super+2` ... `Super+0` Navigate to specific workspace
 
-#### Window manipulation
-* `Super+Q` Kill the current window focused.
+#### Choosing tiling layout
+* `Super+Space` Cycle through the tiling options in the current workspace.
+
+#### Open and close a window
+* `Super+x` Open the App Launcher within a new window.
+* `Super+q` Kill the current focused window.
+
+#### Navigation -- moving the focus 
+... window panes 
+* `Super+d` Focus on the next window pane, left to right.
+* `Super+a` Focus on the previous window pane, right to left.
+
+...workspaces 1 through 10
+* `Super+1`, `Super+2` ... `Super+0` Navigate to specific workspace 1 - 10
+* `Super+s` Focus on the next workspace 1 - 10 (down).
+* `Super+w` Focus on the previous workspace 10 - 1 (up).
+
+...multiple monitors -- Alt+Super+__
+* `Alt+Super+left` Set focus to the left monitor.
+* `Alt+Super+right` Set focus to the right monitor.
+* `Alt+Super+down` Set focus to the downward monitor.
+* `Alt+Super+up` Set focus to the upward monitor.
+
+...to different workspaces and windows via switching applications (gnome key-binding)
+* `Super+tab` Switch between applications
+
+#### Moving a window
+... in the current workspace
+* `Super+left` Move the current window to the left.
+* `Super+right` Move the current window to the right.
+* `Super+up` Move the current window to upper workspace (top).
+* `Super+down` Move the current window to lower workspace (bottom).
+* `Shift+Super+1`, `Shift+Super+2`, ... `Shift+Super+0` Move window to specific workspace  
+
+...to multiple monitors
+* `Shift+Super+a` Move the current window to the monitor on the left.
+* `Shift+Super+d` Move the current window to the monitor on the right.
+* `Shift+Super+w` Move the current window to the upper workspace.
+* `Shift+Super+s` Move the current window to the lower workspace.
+
+... alternate combinations for multiple monitors (gnome keybindings)
+* `Shift+Super+left` Move the current window to the left monitor.
+* `Shift+Super+right` Move the current window to the right monitor.
+* `Shift+Super+down` Move the current window to the downward monitor.
+* `Shift+Super+up` Move the current window to the upward monitor. 
+
+... in combination with the mouse
 * `Super+[MouseDrag]` Move window around.
-* `Super+Shift+A` Move the current window to the left.
-* `Super+Shift+D` Move the current window to the right.
-* `Super+Shift+W` Move the current window to the upper workspace.
-* `Super+Shift+S` Move the current window to the lower workspace.
+
+#### Resize a window
+* `Ctrl+Super+left` Enlarge a window to the left.
+* `Ctrl+Super+up` Enlarge a window upward.
+* `Ctrl+Super+right`Enlarge an window to the  right.
+* `Ctrl+Super+down` Enlarge a window downward.
+
 
 #### Extra Hotkeys
-* `Super+Space` Cycle the tiling layout of the current workspace.
+
+* `Shift+Super+Space` Reverse cycle the tiling layout of the current workspace.
 * `Super+Escape` Toggle the UI of Material-shell, like a Zen mode.
 
 # Installation
 
-#### Get it in two clicks
+#### Get it in two clicks (single-user installation, stable release)
 * Navigate to [extensions.gnome.org](https://extensions.gnome.org/extension/3357/material-shell/)
 * Switch the toggle ON
 
-#### Get the most up to date version with Git
+#### Get the most up to date version with Git (multi-user installation, in development)
 
 1. Check your GNOME Shell version as we only support **gnome-shell >= 3.34.0**
 

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ Setup
 4. To open a second work space, click on the `+` on the left side of the screen, or use `Super+s`.
 5. Turn on the first 6 tiling choices on, e.g., `Maximize, Split ... Half vertical`. Turn off the remaining, especially `Float`. Click on `Confirm layouts` to save.
 6. Click on the tiling icon again and select `Split` from the list of layouts. Increase the number of layouts to `4`.
-7. Use `Super+x` to bring forth the App Launcher and open 4 terminal windows. Once finished, there should 4 (Split) windows on the desktop.
+7. Use `Super+x` bring open App Launcher and then open a terminal window. Do this 4 times. There should 4 (Split) windows on the desktop.
 8. Execute a command in each terminal instance so that they are are distinguishable from each other, e.g. ls, nano, man ls, ping --help.
-9. Use `Super+x` to bring forth the App Launcher and open an email client and LibreWriter.
-
+9. Use `Super+0` to open another workspace, and then open two applications e.g. an  email client and Libre Writer.
+10. Use `Super+0` to open another workspace, and then open an image editor.
 
 Practice
 

--- a/README.md
+++ b/README.md
@@ -124,19 +124,24 @@ Setup
 
 1. The first workspace will be used to view and refer to this README.md file. The 2nd, 3rd,.. 10th will be used for Material-Shell practice.
 2. In the first workspace, click on the tiling icon in the upper right corner. Click on `Tweak available layout`.
-3. Turn off all layout styles except 'floating'. Floating layout  mimics traditional floating windows behaviors.
-4. To open a second work space, click on the `+` on the left side of the screen, or use `Super+s`.
-5. Turn on the first 6 tiling choices on, e.g., `Maximize, Split ... Half vertical`. Turn off the remaining, especially `Float`. Click on `Confirm layouts` to save.
-6. Click on the tiling icon again and select `Split` from the list of layouts. Increase the number of layouts to `4`.
-7. Use `Super+x` bring open App Launcher and then open a terminal window. Do this 4 times. There should 4 (Split) windows on the desktop.
-8. Execute a command in each terminal instance so that they are are distinguishable from each other, e.g. ls, nano, man ls, ping --help.
-9. Use `Super+0` to open another workspace, and then open two applications e.g. an  email client and Libre Writer.
-10. Use `Super+0` to open another workspace, and then open an image editor.
+3. Turn off all layout styles except `Float`. 
+4. Remember that you can return to workspace one, this README file, by using `Super+1`. 
+5. To open a second workspace, click on the `+` on the left side of the screen, or use or `Super+0`.
+6. Turn on the first 6 tiling choices on, e.g., `Maximize, Split ... Half vertical`. Turn off the remaining layouts, especially `Float`. Click on `Confirm layouts` to save.
+7. Click on the tiling icon again and select `Split` from the list of layouts. Increase the number of layouts to `4`.
+8. Use `Super+x` bring open App Launcher and then open a terminal window. Do this 4 times. There should 4 (Split) windows on the desktop.
+9. Execute a command in each terminal instance so that they are are distinguishable from each other, e.g. ls, nano, man ls, ping --help.
+10. Use `Super+0` to open another workspace, and then open two applications e.g. an  email client and Libre Writer.
+11. Use `Super+End` to open another workspace, and then open an image editor.
 
 Practice
 
-9. Cycle through the tiling layouts using `Super+Spacebar`. Notice that the tiling-layout icon updates to represent the current layout.
-10. Experiment with keyboard shortcuts below including opening applications in their own workspaces, moving the focus, moving a window, and resizing a window.
+1. Cycle through the tiling layouts using `Super+Spacebar`. Notice that the tiling-layout icon updates to represent the current layout.
+2. Experiment with keyboard shortcuts, including:
+	Opening applications in their own workspaces
+	Moving the focus within a workspace, to another workspace, and if applicable, to another monitor.
+	Moving a window within a workspace, to another workspace, and if applicable, to another monitor.
+	Resize a window.
 
 Take note of the following:
 
@@ -144,6 +149,7 @@ Take note of the following:
 2. When using a browser, the browser tabs are located below the window panes. Browser tabs and window panes can be similar in appearance.
 3. There isn't a keyboard/mouse equivalent of `Maximize` window. Use the tiling layout icon or `Super+spacebar` to return to a maximized window.
 4. Tiling layout preferences are unique to the each workspace (the preferences do not behave as workspace global settings).
+5. Note that a few Material-Shell keybindings duplicate some Gnome keybindings e.g. `Super+s, Super+PgDown`, `Super+Home`, `Super+End` etc..
 
 ## Hotkeys
 Material-Shell is often used in conjunction with Gnome keyboard-shortcuts, Firefox shortcuts, etc. 

--- a/README.md
+++ b/README.md
@@ -121,24 +121,27 @@ When opening a **new session** Material Shell will **restore every windows** pre
 Getting around using the mouse and keyboard shortcuts
 
 Setup
+
 1. The first workspace is used view this README.md file. The 2nd, 3rd,.. 10th will be used for Material-Shell practice.
 2. In the first workspace, click on the tiling icon in the upper right corner. Click on `Tweak available layout`.
 3. Turn off all layout styles except 'floating'. Floating layout  mimics traditional floating windows behaviors.
-4. To open a second work space, click on the `+` on the left side of the screen, or use `Super+s`
-5. Turn on the first 6 tiling choices on, e.g., `maximize, split ... half vertical`. Turn off the remaining, especially float.
+4. To open a second work space, click on the `+` on the left side of the screen, or use `Super+s`.
+5. Turn on the first 6 tiling choices on, e.g., `maximize, split ... half vertical`. Turn off the remaining, especially `Float`.
 6. Click on the tiling icon again and select `Grid` Increase the number of layouts to `4`.
-7. Use *`Super+x` to bring forth the App Launcher and open 4 terminal windows. Once finished, there should be a grid of 4 windows.
+7. Use `Super+x` to bring forth the App Launcher and open 4 terminal windows. Once finished, there should be a grid of 4 windows.
 8. Execute a command in each terminal instance so that they are are distinguishable from each other, e.g. ls, nano, man ls, ping --help.
 
 Practice
+
 9. Cycle through the tiling layouts using `Super+Spacebar`. Notice that the tiling-layout icon updates to represent the current layout.
 10. Experiment with keyboard shortcuts below including opening applications in their own workspaces, moving the focus, moving a window, and resizing a window.
 
 Take note of the following:
+
 1. The workspace icons are located on the left side of the screen and the window panes (tabs) are located at the top of the screen.
 2. When using a browser, the browser tabs are located below the window panes. Browser tabs and window panes can be similar in appearance.
 3. There isn't a keyboard/mouse equivalent of `Maximize` window. Use the tiling layout icon or `Super+spacebar` to return to a maximized window.
-4. Tiling layout preferences are unique to the each  workspace (the preferences are not global setting for all workspaces).
+4. Tiling layout preferences are unique to the each workspace (the preferences do not behave as workspace global settings).
 
 ## Hotkeys
 Material-Shell is often used in conjunction with Gnome keyboard-shortcuts, Firefox shortcuts, etc. 

--- a/README.md
+++ b/README.md
@@ -122,14 +122,16 @@ Getting around using the mouse and keyboard shortcuts
 
 Setup
 
-1. The first workspace is used view this README.md file. The 2nd, 3rd,.. 10th will be used for Material-Shell practice.
+1. The first workspace will be used to view and refer to this README.md file. The 2nd, 3rd,.. 10th will be used for Material-Shell practice.
 2. In the first workspace, click on the tiling icon in the upper right corner. Click on `Tweak available layout`.
 3. Turn off all layout styles except 'floating'. Floating layout  mimics traditional floating windows behaviors.
 4. To open a second work space, click on the `+` on the left side of the screen, or use `Super+s`.
-5. Turn on the first 6 tiling choices on, e.g., `maximize, split ... half vertical`. Turn off the remaining, especially `Float`.
-6. Click on the tiling icon again and select `Grid` Increase the number of layouts to `4`.
-7. Use `Super+x` to bring forth the App Launcher and open 4 terminal windows. Once finished, there should be a grid of 4 windows.
+5. Turn on the first 6 tiling choices on, e.g., `Maximize, Split ... Half vertical`. Turn off the remaining, especially `Float`. Click on `Confirm layouts` to save.
+6. Click on the tiling icon again and select `Split` from the list of layouts. Increase the number of layouts to `4`.
+7. Use `Super+x` to bring forth the App Launcher and open 4 terminal windows. Once finished, there should 4 (Split) windows on the desktop.
 8. Execute a command in each terminal instance so that they are are distinguishable from each other, e.g. ls, nano, man ls, ping --help.
+9. Use `Super+x` to bring forth the App Launcher and open an email client and LibreWriter.
+
 
 Practice
 

--- a/README.md
+++ b/README.md
@@ -129,19 +129,19 @@ Setup
 5. To open a second workspace, click on the `+` on the left side of the screen, or use or `Super+0`.
 6. Turn on the first 6 tiling choices on, e.g., `Maximize, Split ... Half vertical`. Turn off the remaining layouts, especially `Float`. Click on `Confirm layouts` to save.
 7. Click on the tiling icon again and select `Split` from the list of layouts. Increase the number of layouts to `4`.
-8. Use `Super+x` bring open App Launcher and then open a terminal window. Do this 4 times. There should 4 (Split) windows on the desktop.
-9. Execute a command in each terminal instance so that they are are distinguishable from each other, e.g. ls, nano, man ls, ping --help.
-10. Use `Super+0` to open another workspace, and then open two applications e.g. an  email client and Libre Writer.
+8. Use `Super+x` to open App Launcher, and then open a terminal window. Do this 4 times. There should 4 (Split) windows on the desktop.
+9. Execute a command in each terminal instance so that the terminal windows are distinguishable from each other. For example, execute `ls, nano, man ls, htop` respectively.
+10. Use `Super+0` to open another workspace, and then open two applications, for example, an email client and Libre Writer.
 11. Use `Super+End` to open another workspace, and then open an image editor.
 
 Practice
 
 1. Cycle through the tiling layouts using `Super+Spacebar`. Notice that the tiling-layout icon updates to represent the current layout.
-2. Experiment with keyboard shortcuts, including:
-	Opening applications in their own workspaces
-	Moving the focus within a workspace, to another workspace, and if applicable, to another monitor.
-	Moving a window within a workspace, to another workspace, and if applicable, to another monitor.
-	Resize a window.
+2. Experiment with keyboard shortcuts. Try the following:
+	-Move the focus within a workspace, to another workspace, and if applicable, to another monitor.
+	-Move a window within a workspace, to another workspace, and if applicable, to another monitor.
+	-Resize a window.
+	-Close an application.
 
 Take note of the following:
 
@@ -251,7 +251,7 @@ gnome-extensions enable material-shell@papyelgringo
 * GTK and GNOME Shell theme: [Plata Theme](https://gitlab.com/tista500/plata-theme)
 * Icon theme: [Tela Icon Theme](https://github.com/vinceliuice/Tela-icon-theme)
 
-# Uninstallation 😢
+# Uninstallation (single-user) 😢
 We're sad to see you go. Before you uninstall, leave us some feedback by [opening an issue](https://github.com/material-shell/material-shell/issues/new/choose) - it will be very helpful in improving Material Shell.
 
 1. Open `gnome-tweaks` and disable the `Material Shell` extension **OR** disable it using 
@@ -262,6 +262,9 @@ gnome-extensions disable material-shell@papyelgringo
 ```bash
 rm -rf ~/.local/share/gnome-shell/extensions/material-shell@papyelgringo
 ```
+#(multi-user or development)
+1. Remove via the appropriate package manager.
+
 # History
 The project is based on my earlier work on [Material Awesome](https://github.com/PapyElGringo/material-awesome).
 


### PR DESCRIPTION
Updated and significantly expanded the **keyboard shortcuts** section of README file.  Grouped kb shortcuts by ACTION e.g. Move window, move focus, etc. Created a brief tutorial written for an audience that may not be familiar with the concept of tiling windows managers. The purpose of the tutorial is to help the user become acquainted with M-S functionality in less time. There is likely a case to be made to either rearrange the sections (move installation above tutorial) or break-out some sections into a different document. I'm willing to take direction and put more time into it.

A couple of other items: I could not test the kb shortcuts related to multiple monitors. Also, I've been using the gnome extension version.

This is my first submission to an open-source project and I'm winging it. I welcome feedback not only on the content but also on how the process of contributing to open source is done.  ~