### PR TITLE
Dont disable tiling for windows without a wmclass set

### DIFF
--- a/src/manager/msWindowManager.ts
+++ b/src/manager/msWindowManager.ts
@@ -400,6 +400,7 @@ export class MsWindowManager extends MsManager {
 
     _handleWindow(metaWindow) {
         if (
+            metaWindow.wm_class !== "" &&
             getSettings('layouts')
                 .get_string('windows-excluded')
                 .split(',')


### PR DESCRIPTION
If a window's wm_class is set to "" (which is almost always the case for GTK4 applications),
it'll match the default value of 'windows-excluded' which is "", so tiling was
disabled for GTK4 applications by default.