### PR TITLE
Exit code 0 with warning on wayland

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -141,7 +141,6 @@ def install():
         # Probably wayland
         # It's not possible to restart gnome-shell gracefully when using wayland
         printc(YELLOW, "Installation succeeded. To activate material-shell, please log out and log in again.")
-        exit(1)
 
 
 install()


### PR DESCRIPTION
Closes #608 

Exit code 0 when installation go as planned with displaying a warning for wayland telling user to login/logout session.

## Use case
Don't raise error code since installation without errors
