### PR TITLE
fix move-window-bottom shortcut key

### DIFF
--- a/schemas/bindings.gschema.xml
+++ b/schemas/bindings.gschema.xml
@@ -66,7 +66,7 @@
         </key>
         <key name="move-window-bottom" type="as">
             <default>
-                <![CDATA[['<Super>Bottom']]]>
+                <![CDATA[['<Super>Down']]]>
             </default>
             <summary>Move the current window to lower workspace</summary>
             <description>


### PR DESCRIPTION
The shortcut key "move-window-bottom" was set to [super + bottom], but this should be set to [super + down], shouldn't it?

https://github.com/material-shell/material-shell/blob/a178e266548764ecc98c7f6b69191844ab7bd195/schemas/bindings.gschema.xml#L69