### PR TITLE
Activate AppPlaceholder only once, rename `clicked` property to `activated` (#649)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,26 @@ Some hotkeys might already be used by GNOME Shell - please check your keybinding
 ```bash
 gnome-extensions enable material-shell@papyelgringo
 ```
+
+
 ## Recommended Additional Configuration
 * GTK and GNOME Shell theme: [Plata Theme](https://gitlab.com/tista500/plata-theme)
 * Icon theme: [Tela Icon Theme](https://github.com/vinceliuice/Tela-icon-theme)
+
+# Reset Material Shell
+
+### Reset the Material Shell persistent state
+If you have some wierd behavior or a degradation in time it's can be a good idea to try to reset the Material Shell state.
+
+1. Open Looking Glass tool by pressing `Alt + F2` and type `lg`
+2. Copy past the command `global.set_persistent_state('material-shell-state',new GLib.Variant('s', '{}'));`
+3. Reload the shell
+
+### Reset the Material Shell settings
+If you want to discard all the changes of Material Shell settings and reset to default (Including keybindings)
+1. Open a terminal an copy past `dconf reset -f /org/gnome/shell/extensions/materialshell/`
+
+
 
 # Uninstallation 😢
 We're sad to see you go. Before you uninstall, leave us some feedback by [opening an issue](https://github.com/material-shell/material-shell/issues/new/choose) - it will be very helpful in improving Material Shell.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3005,9 +3005,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yallist": {

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -113,7 +113,7 @@ export class MsWindow extends Clutter.Actor {
         this.windowClone = new Clutter.Clone();
         this.placeholder = new AppPlaceholder(this.app);
         this.metaWindowSignals = [];
-        this.placeholder.connect('clicked', (_) => {
+        this.placeholder.connect('activated', (_) => {
             this.emit('request-new-meta-window');
         });
         this.destroyId = this.connect('destroy', this._onDestroy.bind(this));


### PR DESCRIPTION
Previously, it was possible through an impatient click while waiting for a
slow app to start to activate an app multiple times. That results in multiple
emissions of the `request-new-meta-window` events and chaos ensues.

Fixes #649 by checking and setting `waitForReset` to `true` after a call to
`activate` and emitting `activated` only as the very last action of that
function.