### PR TITLE
focus current window on monitor change (#610)

### DIFF
--- a/src/manager/msWorkspaceManager.ts
+++ b/src/manager/msWorkspaceManager.ts
@@ -803,12 +803,9 @@ export class MsWorkspaceManager extends MsManager {
                 Math.floor(
                     msWorkspace.msWorkspaceActor.tileableContainer.width / 2
                 ),
-            containerY +
-                Math.floor(
-                    msWorkspace.msWorkspaceActor.tileableContainer.height / 2
-                )
+            0
         );
 
-        msWorkspace.refreshFocus();
+        msWorkspace.refreshFocus(true);
     }
 }


### PR DESCRIPTION
Forces the workspace to focus the current window and moves the mouse pointer to the top of the screen to not mess with split screen layout. 
This issue was presented on #610 