### PR TITLE
Don't move vertical panel on search

### DIFF
--- a/src/layout/verticalPanel/verticalPanel.ts
+++ b/src/layout/verticalPanel/verticalPanel.ts
@@ -57,10 +57,6 @@ export class PanelContent extends St.BoxLayout {
         this.searchButton = new MatPanelButton({
             child: this.buttonIcon,
             primary: true,
-            height: Math.max(
-                48,
-                Me.msThemeManager.getPanelSize(Main.layoutManager.primaryIndex)
-            ),
         });
 
         this.searchButton.connect('clicked', () => {
@@ -79,10 +75,6 @@ export class PanelContent extends St.BoxLayout {
         Me.msThemeManager.connect('panel-size-changed', () => {
             this.buttonIcon.set_icon_size(
                 Me.msThemeManager.getPanelSizeNotScaled() / 2
-            );
-            this.searchButton.height = Math.max(
-                48,
-                Me.msThemeManager.getPanelSize(Main.layoutManager.primaryIndex)
             );
 
             this.queue_relayout();
@@ -265,12 +257,12 @@ export class MsPanel extends St.BoxLayout {
                     Me.msThemeManager.verticalPanelPosition ===
                     VerticalPanelPositionEnum.LEFT
                 ) {
-                    this.insert_child_below(
+                    this.insert_child_above(
                         this.searchContent,
                         this.panelContent
                     );
                 } else {
-                    this.insert_child_above(
+                    this.insert_child_below(
                         this.searchContent,
                         this.panelContent
                     );
@@ -281,9 +273,9 @@ export class MsPanel extends St.BoxLayout {
                     Me.msThemeManager.verticalPanelPosition ===
                     VerticalPanelPositionEnum.LEFT
                 ) {
-                    this.insert_child_below(this.divider, this.panelContent);
-                } else {
                     this.insert_child_above(this.divider, this.panelContent);
+                } else {
+                    this.insert_child_below(this.divider, this.panelContent);
                 }
             }
 


### PR DESCRIPTION
This is just a small UX improvement. When opening the search panel, the vertical panel is currently moving. That changes the buttons placement, which is annoying, specially when using the mouse. With this change the panel stays in place, making it easier to quickly open and close the search panel by just clicking in the same position on the corner of the screen.

Also removed the minimum height for the search button since the rectangular button looks much worse than not aligning to the search bar.

Not sure if this is the best way to do this. Comments are appreciated.