### PR TITLE
Invert scroll direction on LayoutSwitcher

### DIFF
--- a/src/layout/msWorkspace/horizontalPanel/layoutSwitcher.ts
+++ b/src/layout/msWorkspace/horizontalPanel/layoutSwitcher.ts
@@ -45,10 +45,10 @@ export class LayoutSwitcher extends St.BoxLayout {
         this.switcherButton.connect('scroll-event', (_, event) => {
             switch (event.get_scroll_direction()) {
                 case Clutter.ScrollDirection.UP:
-                    this.msWorkspace.nextLayout(1);
+                    this.msWorkspace.nextLayout(-1);
                     break;
                 case Clutter.ScrollDirection.DOWN:
-                    this.msWorkspace.nextLayout(-1);
+                    this.msWorkspace.nextLayout(1);
                     break;
             }
         });


### PR DESCRIPTION
Just inverting the scroll direction so that scrolling down changes to layout down the list and scrolling up changes up the list. It was strange to see it scrolling backwards when scrolling with the menu open.