### PR TITLE
Fix keyboard navigation swapping Tileables' icons

### DIFF
--- a/src/layout/msWorkspace/horizontalPanel/taskBar.ts
+++ b/src/layout/msWorkspace/horizontalPanel/taskBar.ts
@@ -506,11 +506,11 @@ export class TileableItem extends TaskBarItem {
     setTileable(tileable) {
         if (tileable === this.tileable) return;
         if (this.titleSignalKiller) this.titleSignalKiller();
+        this.tileable = tileable;
+        this.app = tileable.app;
         if (this.icon) {
             this.buildIcon(this.lastHeight);
         }
-        this.tileable = tileable;
-        this.app = tileable.app;
         this.titleSignalKiller = this.signalManager.observe(
             this.tileable,
             'title-changed',


### PR DESCRIPTION
@PapyElGringo Hi, me again. I like your last fix, stability got much better for me on taskBar, it used to crash the shell a lot before. There's still a problem with swapping Tileables with the keyboard, though. The icon isn't always swapping because `buildIcon()` uses `this.app`, so it must be called after `this.app = tileable.app;`.