### PR TITLE
Fix crash when closing first workspace  (#535)

### DIFF
--- a/src/widget/material/button.ts
+++ b/src/widget/material/button.ts
@@ -148,11 +148,12 @@ export class MatButton extends St.Widget {
 
     // eslint-disable-next-line camelcase
     set_child(child?: St.Widget) {
-        if (!child) return;
         if (this.child) {
             this.remove_child(this.child);
         }
         this.child = child;
-        this.add_child(child);
+        if (child) {
+            this.add_child(child);
+        }
     }
 }


### PR DESCRIPTION
After some help from the [devs @ gnome-shell](https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/2052), it looks like that reordering the `set_child()` method fixes the issue #535 . 

At least for me closing the first workspace does not crash the desktop anymore.

