### PR TITLE
Fix typo in description of Panels size

### DIFF
--- a/schemas/settings.gschema.xml
+++ b/schemas/settings.gschema.xml
@@ -51,7 +51,7 @@
         <key name="panel-size" type="i">
             <default>48</default>
             <summary>Panels size</summary>
-            <description>Width of the vertical panel and heigh of the horizontal panels.</description>
+            <description>Width of the vertical panel and height of the horizontal panels.</description>
         </key>
         <key name="panel-opacity" type="i">
             <default>100</default>


### PR DESCRIPTION
A one character change fixing a small typo in the settings.