### PR TITLE
Wrap setting description to avoid too wide window

### DIFF
--- a/src/prefs/ui/setting_list_box_row.ui
+++ b/src/prefs/ui/setting_list_box_row.ui
@@ -21,6 +21,7 @@
                             <object class="GtkLabel" id="description_label">
                                 <property name="xalign">0</property>
                                 <property name="use-markup">1</property>
+                                <property name="wrap">1</property>
                                 <property name="margin-top">8</property>
                                 <property name="margin-start">8</property>
                                 <property name="margin-bottom">8</property>


### PR DESCRIPTION
The last setting has a very long description and the labels do not wrap by default. This makes the settings window too large to be usable (at least on my screen).

With the change: ![material-settings](https://user-images.githubusercontent.com/4035835/156464371-b52aaf95-3159-4cfe-8236-4f10fcc066e9.png)
