### PR TITLE
Improve incompatible extensions handling

### DIFF
--- a/src/module/disableIncompatibleExtensionsModule.ts
+++ b/src/module/disableIncompatibleExtensionsModule.ts
@@ -10,6 +10,8 @@ const incompatibleExtensions = [
     'ubuntu-dock@ubuntu.com',
     'dash-to-dock@micxgx.gmail.com',
     'ding@rastersoft.com',
+    // Pop Shell is another window manager, it will very likely cause massive conflicts with Material Shell.
+    'pop-shell@system76.com',
     // 'improved-workspace-indicator' adds styling to the window tabs in a weird greenish color.
     // That extension is very much redundant anyway, given that MS has its own workspace indicator.
     'improved-workspace-indicator@michaelaquilina.github.io',

--- a/src/module/disableIncompatibleExtensionsModule.ts
+++ b/src/module/disableIncompatibleExtensionsModule.ts
@@ -31,15 +31,12 @@ export class DisableIncompatibleExtensionsModule {
 
     disableExtensions() {
         for (const incompatibleExtension of incompatibleExtensions) {
-            const extension = Main.extensionManager.lookup(
-                incompatibleExtension
-            );
-            if (extension) {
-                try {
-                    extension.stateObj.disable();
-                } catch (e) {
-                    Me.logFocus('disable error', incompatibleExtension, e);
+            try {
+                if(Main.extensionManager.disableExtension(incompatibleExtension)) {
+                    Me.log(`Disabled gnome extension ${incompatibleExtension} because it is incompatible with Material Shell`);
                 }
+            } catch (e) {
+                Me.logFocus('disable error', incompatibleExtension, e);
             }
         }
     }

--- a/src/module/disableIncompatibleExtensionsModule.ts
+++ b/src/module/disableIncompatibleExtensionsModule.ts
@@ -10,6 +10,9 @@ const incompatibleExtensions = [
     'ubuntu-dock@ubuntu.com',
     'dash-to-dock@micxgx.gmail.com',
     'ding@rastersoft.com',
+    // 'improved-workspace-indicator' adds styling to the window tabs in a weird greenish color.
+    // That extension is very much redundant anyway, given that MS has its own workspace indicator.
+    'improved-workspace-indicator@michaelaquilina.github.io',
 ];
 
 let originalFunction: { apply: (uuid: any, args: IArguments) => void } | null;


### PR DESCRIPTION
**Description**

* Disables extensions using a more public api which actually seems to work.
  Before, it didn't seem like MS managed to disable extensions properly.
* Adds pop shell as another incomaptible extension:
  Pop Shell is another window manager, it will very likely cause massive conflicts with Material Shell.
* Add 'improved-workspace-indicator' as an incompatible extension.
  'improved-workspace-indicator' adds styling to the window tabs in a weird greenish color.
That extension is very much redundant anyway when used with MS, given that MS has its own workspace indicator.

**Checklist**:

- [x] I used indents of four spaces in code and two spaces in documentation
- [x] I have performed a self-review of my own code, it does not generate any errors
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation or will submit them later
- [x] I have recompiled gschgema (if there were any changes)
- [x] Changes to the SASS were done to the variables only or following the proper way