### PR TITLE
Fix pressing 'Close' on persistent tabs not working.

### DIFF
--- a/src/layout/msWorkspace/horizontalPanel/taskBar.ts
+++ b/src/layout/msWorkspace/horizontalPanel/taskBar.ts
@@ -211,6 +211,9 @@ export class TaskBar extends St.Widget {
                 tileable.kill();
             });
             item.connect('close-clicked', (_) => {
+                // If a user manually clicks the 'Close' button we make the tileable not persistent
+                // as otherwise it will not be possible to close it.
+                tileable.persistent = false;
                 tileable.kill();
             });
         } else {


### PR DESCRIPTION

**Description**

Previously, right clicking on a persistent tab and pressing the `Close` option would just close the app, but not remove the tab. Clicking `Close` again on a persistent tab which only had a placeholder would do nothing.

This PR fixes this so that it is possible to close persistent tabs.


**Checklist**:

- [x] I used indents of four spaces in code and two spaces in documentation
- [x] I have performed a self-review of my own code, it does not generate any errors
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation or will submit them later
- [x] I have recompiled gschgema (if there were any changes)
- [x] Changes to the SASS were done to the variables only or following the proper way