### PR TITLE
Add option to disable App Launcher

### DIFF
--- a/schemas/settings.gschema.xml
+++ b/schemas/settings.gschema.xml
@@ -98,6 +98,11 @@
             <summary>Focus effect</summary>
             <description>Define which focus effect to apply when using tiling layouts</description>
         </key>
+        <key name="app-launcher" type="b">
+            <default>true</default>
+            <summary>Show app launcher</summary>
+            <description>Show app launcher on empty workspaces and at the end of the task bar</description>
+        </key>
     </schema>
     <schema id="org.gnome.shell.extensions.materialshell.tweaks" path="/org/gnome/shell/extensions/materialshell/tweaks/" >
         <key name="cycle-through-windows" type="b" >

--- a/src/layout/msWorkspace/horizontalPanel/taskBar.ts
+++ b/src/layout/msWorkspace/horizontalPanel/taskBar.ts
@@ -129,7 +129,7 @@ export class TaskBar extends St.Widget {
             let item = this.createNewItemForTileable(tileable);
             this.taskButtonContainer.add_child(item);
         }
-        if (this.items[this.msWorkspace.focusedIndex]) {
+        if (this.msWorkspace.focusedIndex !== null && this.items[this.msWorkspace.focusedIndex]) {
             this.items[this.msWorkspace.focusedIndex].setActive(true);
         }
     }
@@ -200,7 +200,9 @@ export class TaskBar extends St.Widget {
     }
 
     getActiveItem() {
-        return this.items[this.msWorkspace.focusedIndex];
+        if (this.msWorkspace.focusedIndex !== null) {
+            return this.items[this.msWorkspace.focusedIndex];
+        }
     }
 
     createNewItemForTileable(tileable: Tileable) {
@@ -238,14 +240,20 @@ export class TaskBar extends St.Widget {
         const themeNode = this.get_theme_node();
         const contentBox = themeNode.get_content_box(box);
         Allocate(this.taskButtonContainer, contentBox, flags);
+        const activeItem = this.getActiveItem();
 
-        const taskActiveIndicatorBox = new Clutter.ActorBox({
-            x1: this.getActiveItem().x,
-            x2: this.getActiveItem().x + this.getActiveItem().width,
-            y1: contentBox.get_height() - this.taskActiveIndicator.height,
-            y2: contentBox.get_height(),
-        });
-        Allocate(this.taskActiveIndicator, taskActiveIndicatorBox, flags);
+        if (activeItem) {
+            this.taskActiveIndicator.show();
+            const taskActiveIndicatorBox = new Clutter.ActorBox({
+                x1: activeItem.x,
+                x2: activeItem.x + activeItem.width,
+                y1: contentBox.get_height() - this.taskActiveIndicator.height,
+                y2: contentBox.get_height(),
+            });
+            Allocate(this.taskActiveIndicator, taskActiveIndicatorBox, flags);
+        } else {
+            this.taskActiveIndicator.hide();
+        }
     }
 
     _onDestroy() {

--- a/src/layout/msWorkspace/tilingLayouts/baseResizeableTiling.ts
+++ b/src/layout/msWorkspace/tilingLayouts/baseResizeableTiling.ts
@@ -147,6 +147,8 @@ export class BaseResizeableTilingLayout<S extends { key: string }> extends BaseT
     }
 
     updateMainPortionLength(length: number) {
+        if (length <= 0) return; // Safeguard against infinite loops that freeze the OS
+
         while (this.mainPortion.portionLength > length) {
             this.mainPortion.pop();
         }
@@ -248,7 +250,9 @@ export class BaseResizeableTilingLayout<S extends { key: string }> extends BaseT
         });
     }
 
-    onFocusChanged(tileable: Tileable, oldTileable: Tileable | null) {
+    onFocusChanged(tileable: Tileable | null, oldTileable: Tileable | null) {
+        if (!tileable) return;
+
         this.setUnFocusEffect(tileable, this.currentFocusEffect, true);
         if (oldTileable) {
             if (

--- a/src/layout/msWorkspace/tilingLayouts/baseTiling.ts
+++ b/src/layout/msWorkspace/tilingLayouts/baseTiling.ts
@@ -166,6 +166,7 @@ export class BaseTilingLayout<S extends { key: string }> extends Clutter.LayoutM
     }
 
     showAppLauncher() {
+        if (!this.msWorkspace.appLauncher) return;
         const actor = this.msWorkspace.appLauncher;
 
         actor.visible = true;
@@ -185,6 +186,7 @@ export class BaseTilingLayout<S extends { key: string }> extends Clutter.LayoutM
     }
 
     hideAppLauncher() {
+        if (!this.msWorkspace.appLauncher) return;
         const actor = this.msWorkspace.appLauncher;
         actor.ease({
             scale_x: 0.8,
@@ -231,12 +233,17 @@ export class BaseTilingLayout<S extends { key: string }> extends Clutter.LayoutM
             this.restoreTileable(tileable);
         });
         if (
+            this.msWorkspace.appLauncher &&
             this.msWorkspace.appLauncher.visible &&
             this.msWorkspace.tileableFocused !== this.msWorkspace.appLauncher
         ) {
             this.hideAppLauncher();
         }
-        if (tileableList.length == 1 && !this.msWorkspace.appLauncher.visible) {
+        if (
+            this.msWorkspace.appLauncher &&
+            !this.msWorkspace.appLauncher.visible &&
+            tileableList.length == 1
+        ) {
             this.showAppLauncher();
         }
         this.tileAll();
@@ -250,7 +257,7 @@ export class BaseTilingLayout<S extends { key: string }> extends Clutter.LayoutM
         );
     }
 
-    onFocusChanged(tileable: Tileable, oldTileable: Tileable | null) {
+    onFocusChanged(tileable: Tileable | null, oldTileable: Tileable | null) {
         if (tileable === this.msWorkspace.appLauncher) {
             this.tileAll();
             GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {

--- a/src/layout/msWorkspace/tilingLayouts/custom/grid.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/grid.ts
@@ -13,6 +13,8 @@ export class GridLayout extends BaseResizeableTilingLayout<{ key: 'grid' }> {
     static label = 'Grid';
 
     updateMainPortionLength(length: number) {
+        if (length <= 0) return; // Safeguard against infinite loops that freeze the OS
+
         const columnLength = Math.ceil(Math.sqrt(length));
         const rowLength = Math.ceil(length / columnLength);
 

--- a/src/layout/msWorkspace/tilingLayouts/custom/half.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/half.ts
@@ -9,6 +9,8 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 @registerGObjectClass
 export class HalfLayoutBase<S extends { key: string }> extends BaseResizeableTilingLayout<S> {
     updateMainPortionLength(length: number) {
+        if (length <= 0) return; // Safeguard against infinite loops that freeze the OS
+
         while (this.mainPortion.portionLength > length) {
             this.mainPortion.pop();
         }

--- a/src/layout/msWorkspace/tilingLayouts/custom/ratio.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/ratio.ts
@@ -13,6 +13,8 @@ export class RatioLayout extends BaseResizeableTilingLayout<{ key: 'ratio' }> {
     static label = 'Ratio';
 
     updateMainPortionLength(length: number) {
+        if (length <= 0) return; // Safeguard against infinite loops that freeze the OS
+
         const pushInPortion = (portion: Portion) => {
             if (portion.children.length === 2) {
                 pushInPortion(portion.children[1]);

--- a/src/layout/msWorkspace/tilingLayouts/float.ts
+++ b/src/layout/msWorkspace/tilingLayouts/float.ts
@@ -57,6 +57,7 @@ export class FloatLayout extends BaseTilingLayout<FloatLayoutState> {
     }
 
     showAppLauncher() {
+        if (!this.msWorkspace.appLauncher) return;
         const actor = this.msWorkspace.appLauncher;
         actor.x = 0;
         actor.y = 0;
@@ -65,9 +66,12 @@ export class FloatLayout extends BaseTilingLayout<FloatLayoutState> {
         super.showAppLauncher();
     }
 
-    onFocusChanged(tileableFocused: Tileable, oldTileable: Tileable | null) {
+    onFocusChanged(tileableFocused: Tileable | null, oldTileable: Tileable | null) {
+        if (!tileableFocused) return;
+
         if (
             tileableFocused != this.msWorkspace.appLauncher &&
+            this.msWorkspace.appLauncher &&
             this.msWorkspace.appLauncher.visible
         ) {
             this.msWorkspace.msWorkspaceActor.tileableContainer.set_child_below_sibling(

--- a/src/layout/msWorkspace/tilingLayouts/maximize.ts
+++ b/src/layout/msWorkspace/tilingLayouts/maximize.ts
@@ -65,6 +65,7 @@ export class MaximizeLayout extends BaseTilingLayout<MaximizeLayoutState> {
     }
 
     showAppLauncher() {
+        if (!this.msWorkspace.appLauncher) return;
         const actor = this.msWorkspace.appLauncher;
         actor.visible = true;
     }
@@ -73,7 +74,9 @@ export class MaximizeLayout extends BaseTilingLayout<MaximizeLayoutState> {
         // Never hide the Applauncher
     }
 
-    onFocusChanged(windowFocused: Tileable, oldWindowFocused: Tileable | null) {
+    onFocusChanged(windowFocused: Tileable | null, oldWindowFocused: Tileable | null) {
+        if (!windowFocused) return;
+
         if (windowFocused.dragged) {
             this.displayTileable(windowFocused);
         } else {

--- a/src/layout/msWorkspace/tilingLayouts/split.ts
+++ b/src/layout/msWorkspace/tilingLayouts/split.ts
@@ -60,6 +60,13 @@ export class SplitLayout extends BaseResizeableTilingLayout<SplitLayoutState> {
     }
 
     updateActiveTileableListFromFocused() {
+        if (this.msWorkspace.focusedIndex === null && this.msWorkspace.tileableList.length > 0) {
+            this.msWorkspace.focusedIndex = 0;
+        } else if (this.msWorkspace.focusedIndex === null) {
+            this.activeTileableList = this.msWorkspace.tileableList;
+            this.baseIndex = 0;
+            return;
+        }
         this.baseIndex = Math.max(
             0,
             Math.min(
@@ -100,9 +107,11 @@ export class SplitLayout extends BaseResizeableTilingLayout<SplitLayoutState> {
     }
 
     onFocusChanged(
-        tileableFocused: Tileable,
+        tileableFocused: Tileable | null,
         oldTileableFocused: Tileable | null
     ) {
+        if (!tileableFocused) return;
+
         if (this.activeTileableList.includes(tileableFocused)) {
             this.activeTileableList.forEach((tileable) => {
                 this.setUnFocusEffect(
@@ -131,8 +140,8 @@ export class SplitLayout extends BaseResizeableTilingLayout<SplitLayoutState> {
                 newIndex + this._state.nbOfColumns
             );
         }
-        this.baseIndex = this.msWorkspace.tileableList.indexOf(
-            this.activeTileableList[0]
+        this.baseIndex = Math.max(0,
+            this.msWorkspace.tileableList.indexOf(this.activeTileableList[0])
         );
 
         this.startTransition(oldTileableList, this.activeTileableList);
@@ -146,6 +155,7 @@ export class SplitLayout extends BaseResizeableTilingLayout<SplitLayoutState> {
     }
 
     showAppLauncher() {
+        if (!this.msWorkspace.appLauncher) return;
         const actor = this.msWorkspace.appLauncher;
         actor.visible = true;
     }

--- a/src/manager/msThemeManager.ts
+++ b/src/manager/msThemeManager.ts
@@ -113,6 +113,9 @@ export class MsThemeManager extends MsManager {
         this.observe(this.themeSettings, 'changed::focus-effect', () => {
             this.emit('focus-effect-changed');
         });
+        this.observe(this.themeSettings, 'changed::app-launcher', () => {
+            this.emit('app-launcher-changed');
+        });
     }
 
     get verticalPanelPosition() {
@@ -168,6 +171,10 @@ export class MsThemeManager extends MsManager {
 
     get focusEffect() {
         return this.themeSettings.get_enum('focus-effect');
+    }
+
+    get appLauncher() {
+        return this.themeSettings.get_boolean('app-launcher');
     }
 
     isColorDark(color: string) {

--- a/src/prefs/prefs.ts
+++ b/src/prefs/prefs.ts
@@ -430,6 +430,7 @@ class PrefsWidget extends Gtk.Box {
         theme.addSetting('clock-horizontal', WidgetType.BOOLEAN);
         theme.addSetting('clock-app-launcher', WidgetType.BOOLEAN);
         theme.addSetting('focus-effect', WidgetType.COMBO);
+        theme.addSetting('app-launcher', WidgetType.BOOLEAN);
         this._settings_box.append(theme);
 
         const tweaks = new SettingCategoryListBox(


### PR DESCRIPTION
# Add option to disable App Launcher

By default nothing should change, but when the new option is toggled off the App Launcher won't appear anymore on an empty Workspace and at the end of the Task Bar.

This change needed extensive changes because many places assumed the App Launcher would always exist. This PR requires a fair amount of testing before it can be deemed safe to merge.

---

**EDIT:** After discussions on Discord, it's understood this PR is unlikely to be merged, because it doesn't align with the general vision for Material Shell. Improving the App Launcher, instead of removing it, is the way forward.