### PR TITLE
Fix middle-click and close-button

### DIFF
--- a/src/layout/msWorkspace/horizontalPanel/taskBar.ts
+++ b/src/layout/msWorkspace/horizontalPanel/taskBar.ts
@@ -209,10 +209,10 @@ export class TaskBar extends St.Widget {
             item = new TileableItem(tileable);
             this.menuManager.addMenu(assertNotNull(item.menu));
             item.connect('middle-clicked', (_) => {
-                tileable.kill();
+                if (item.tileable instanceof MsWindow) item.tileable.kill();
             });
             item.connect('close-clicked', (_) => {
-                tileable.kill();
+                if (item.tileable instanceof MsWindow) item.tileable.kill();
             });
         } else {
             item = new IconTaskBarItem(


### PR DESCRIPTION
Middle-click and close-button were closing the wrong window after a list reorder with keyboard shortcuts due to a static reference to a Tileable in the event handlers. Change to dynamically get the current Tileable from the TileableItem to fix that.