### PR TITLE
Make 'tileableList-changed' not send the old list with the event.

### DIFF
--- a/src/layout/msWorkspace/horizontalPanel/taskBar.ts
+++ b/src/layout/msWorkspace/horizontalPanel/taskBar.ts
@@ -21,6 +21,7 @@ import { main as Main } from 'ui';
 import { layout } from 'ui';
 import Monitor = layout.Monitor;
 import { MsApplicationLauncher } from 'src/widget/msApplicationLauncher';
+import { diffLists } from 'src/utils/diff_list';
 
 /** Extension imports */
 const Me = imports.misc.extensionUtils.getCurrentExtension();
@@ -97,8 +98,8 @@ export class TaskBar extends St.Widget {
         this.msWorkspaceSignals = [
             msWorkspace.connect(
                 'tileableList-changed',
-                (_, newTileableList, oldTileableList) => {
-                    this.onTileableListChange(newTileableList, oldTileableList);
+                (_, newTileableList) => {
+                    this.onTileableListChange(newTileableList);
                 }
             ),
             msWorkspace.connect(
@@ -147,14 +148,8 @@ export class TaskBar extends St.Widget {
      */
     onTileableListChange(
         newTileableList: Tileable[],
-        oldTileableList: Tileable[]
     ) {
-        const tileableToRemove = oldTileableList.filter(
-            (tileable) => !newTileableList.includes(tileable)
-        );
-        const tileableToAdd = newTileableList.filter(
-            (tileable) => !oldTileableList.includes(tileable)
-        );
+        let { added: tileableToAdd, removed: tileableToRemove } = diffLists(this.items.map(item => item.tileable), newTileableList);
 
         for (let tileable of tileableToRemove) {
             let item = assertNotNull(this.getTaskBarItemOfTileable(tileable));

--- a/src/layout/msWorkspace/msWorkspace.ts
+++ b/src/layout/msWorkspace/msWorkspace.ts
@@ -232,8 +232,6 @@ export class MsWorkspace extends WithSignals {
             reparentActor(msWindow, this.msWorkspaceActor.tileableContainer);
         }
 
-        const oldTileableList = [...this.tileableList];
-
         let insertAt = this.tileableList.length - 1;
 
         // Do not insert tileable after App Launcher
@@ -248,7 +246,7 @@ export class MsWorkspace extends WithSignals {
             this.focusTileable(msWindow);
         }
         this.msWorkspaceActor.updateUI();
-        await this.emitTileableListChangedOnce(oldTileableList);
+        await this.emitTileableListChangedOnce();
     }
 
     async removeMsWindow(msWindow: MsWindow) {
@@ -257,7 +255,6 @@ export class MsWorkspace extends WithSignals {
         if (this.msWindowList.indexOf(msWindow) === -1) return;
         const tileableIsFocused = msWindow === this.tileableFocused;
         const tileableIndex = this.tileableList.indexOf(msWindow);
-        const oldTileableList: (Tileable | null)[] = [...this.tileableList];
         this.tileableList.splice(tileableIndex, 1);
         // Update the focusedIndex
         if (
@@ -271,7 +268,7 @@ export class MsWorkspace extends WithSignals {
         ) {
             this.focusedIndex--;
         }
-        await this.emitTileableListChangedOnce(oldTileableList);
+        await this.emitTileableListChangedOnce();
         // If there's no more focused msWindow on this workspace focus the last one
 
         if (tileableIsFocused) {
@@ -282,7 +279,7 @@ export class MsWorkspace extends WithSignals {
         this.refreshFocus();
     }
 
-    async emitTileableListChangedOnce(oldTileableList: (Tileable | null)[]) {
+    async emitTileableListChangedOnce() {
         if (!this.emitTileableChangedInProgress) {
             this.emitTileableChangedInProgress = new Promise<void>(
                 (resolve) => {
@@ -290,8 +287,7 @@ export class MsWorkspace extends WithSignals {
                         delete this.emitTileableChangedInProgress;
                         this.emit(
                             'tileableList-changed',
-                            this.tileableList,
-                            oldTileableList
+                            this.tileableList
                         );
                         resolve();
                         return GLib.SOURCE_REMOVE;
@@ -305,10 +301,9 @@ export class MsWorkspace extends WithSignals {
     swapTileable(firstTileable: Tileable, secondTileable: Tileable) {
         const firstIndex = this.tileableList.indexOf(firstTileable);
         const secondIndex = this.tileableList.indexOf(secondTileable);
-        const oldTileableList = [...this.tileableList];
         this.tileableList[firstIndex] = secondTileable;
         this.tileableList[secondIndex] = firstTileable;
-        this.emit('tileableList-changed', this.tileableList, oldTileableList);
+        this.emit('tileableList-changed', this.tileableList);
     }
 
     swapTileableLeft(tileable: Tileable) {
@@ -421,33 +416,30 @@ export class MsWorkspace extends WithSignals {
     }
 
     setTileableBefore(tileableToMove: Tileable, tileableRelative: Tileable) {
-        const oldTileableList = [...this.tileableList];
         const tileableToMoveIndex = this.tileableList.indexOf(tileableToMove);
         this.tileableList.splice(tileableToMoveIndex, 1);
 
         const tileableRelativeIndex =
             this.tileableList.indexOf(tileableRelative);
         this.tileableList.splice(tileableRelativeIndex, 0, tileableToMove);
-        this.emit('tileableList-changed', this.tileableList, oldTileableList);
+        this.emit('tileableList-changed', this.tileableList);
     }
 
     setTileableAfter(tileableToMove: Tileable, tileableRelative: Tileable) {
-        const oldTileableList = [...this.tileableList];
         const tileableToMoveIndex = this.tileableList.indexOf(tileableToMove);
         this.tileableList.splice(tileableToMoveIndex, 1);
 
         const tileableRelativeIndex =
             this.tileableList.indexOf(tileableRelative);
         this.tileableList.splice(tileableRelativeIndex + 1, 0, tileableToMove);
-        this.emit('tileableList-changed', this.tileableList, oldTileableList);
+        this.emit('tileableList-changed', this.tileableList);
     }
 
     setTileableAtIndex(tileableToMove: Tileable, index: number) {
-        const oldTileableList = [...this.tileableList];
         const tileableToMoveIndex = this.tileableList.indexOf(tileableToMove);
         this.tileableList.splice(tileableToMoveIndex, 1);
         this.tileableList.splice(index, 0, tileableToMove);
-        this.emit('tileableList-changed', this.tileableList, oldTileableList);
+        this.emit('tileableList-changed', this.tileableList);
     }
 
     nextLayout(direction: number) {

--- a/src/layout/msWorkspace/tilingLayouts/split.ts
+++ b/src/layout/msWorkspace/tilingLayouts/split.ts
@@ -76,10 +76,9 @@ export class SplitLayout extends BaseResizeableTilingLayout<SplitLayoutState> {
     }
 
     onTileableListChanged(
-        newWindows: Tileable[],
-        oldWindows: (Tileable | null)[]
+        newWindows: Tileable[]
     ) {
-        super.onTileableListChanged(newWindows, oldWindows);
+        super.onTileableListChanged(newWindows);
         this.updateActiveTileableListFromFocused();
         this.refreshVisibleActors();
     }

--- a/src/utils/diff_list.ts
+++ b/src/utils/diff_list.ts
@@ -1,0 +1,11 @@
+/** Given a list `lhs` which has been changed into `rhs`, returns which items have been added to `rhs` and which have been removed.
+ * The order of items does not matter.
+ *
+ * The result is unspecified if any list contains duplicate items.
+ */
+export function diffLists<T>(lhs: T[], rhs: T[]): { added: T[]; removed: T[] } {
+    return {
+        added: rhs.filter((x) => !lhs.includes(x)),
+        removed: lhs.filter((x) => !rhs.includes(x)),
+    };
+}


### PR DESCRIPTION
Previously theoretical race conditions could cause the old list to be inaccurate (if multiple updates happened before the event fired). I have not observed this to happen, but it seemed a bit sketchy. However, primarily I made this change because it makes some other changes I'm working on much more convenient.
Now the receivers that need to diff against the old list will keep track of this info themselves, which should be more robust.
This also simplifies the code a bit.
