### PR TITLE
Fix trying to access destroyed objects when debugging is enabled.

### DIFF
--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -939,6 +939,12 @@ export class MsWindow extends Clutter.Actor {
     }
 
     toString() {
+        // When MS function parameter logging is enabled, toString may be called on windows that have been destroyed.
+        // So we need to guard against this. super.toString would otherwise try to access the destroyed C object.
+        if (this.destroyed) {
+            return `[destroyed MsWindow - ${this.app.get_name()}]`;
+        }
+
         const string = super.toString();
         return `${string.slice(0, string.length - 1)} ${this.app.get_name()}]`;
     }


### PR DESCRIPTION
**Description**

When MS function parameter logging is enabled, toString may be called on windows that have been destroyed.
So we need to guard against this.

**Checklist**:

- [x] I used indents of four spaces in code and two spaces in documentation
- [x] I have performed a self-review of my own code, it does not generate any errors
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation or will submit them later
- [x] I have recompiled gschgema (if there were any changes)
- [x] Changes to the SASS were done to the variables only or following the proper way