### PR TITLE
Fix use-after-destroy in task bar when rebuilding the icon. 

### DIFF
--- a/src/utils/idle_debounce.ts
+++ b/src/utils/idle_debounce.ts
@@ -1,0 +1,49 @@
+import * as GLib from 'glib';
+import { assertNotNull } from './assert';
+
+/** Helper to run a function with `GLib.idle_add`, but with automatic debouncing and a convenient cancel function */
+export class IdleDebounce<P extends any[]> {
+    private scheduleInfo: {
+        signal: number,
+        args: P
+     } | null = null;
+    private readonly f: (...args: P) => void;
+
+    constructor(f: (...args: P) => void) {
+        this.f = f;
+    }
+
+    /** Run the function `f` as soon as possible when there are no other high priority tasks.
+     * Calling this multiple times before the function runs is equivalent to just calling it once.
+     *
+     * The arguments passed to the function will be the last arguments that `schedule` is called with.
+     *
+     * See https://docs.gtk.org/glib/main-loop.html
+     */
+    schedule(...args: P) {
+        if (this.scheduleInfo === null) {
+            this.scheduleInfo = {
+                signal: GLib.idle_add(
+                    GLib.PRIORITY_DEFAULT_IDLE,
+                    () => {
+                        const info = assertNotNull(this.scheduleInfo);
+                        this.scheduleInfo = null;
+                        this.f(...info.args);
+                        return GLib.SOURCE_REMOVE;
+                    }
+                ),
+                args: args
+            }
+        } else {
+            this.scheduleInfo.args = args;
+        }
+    }
+
+    /** Cancel running the function if it has been scheduled */
+    cancel() {
+        if (this.scheduleInfo !== null) {
+            GLib.Source.remove(this.scheduleInfo.signal);
+            this.scheduleInfo = null;
+        }
+    }
+}


### PR DESCRIPTION
Previously, this could happen in a single frame in the TileableItem class:

1. allocate is called, causing an idle_add to be added for rebuilding the icon.
2. allocate is called again in the same frame, causing another idle_add, overwriting the previous one.
3. The task bar item is destroyed, cancelling the second idle_add, but not the first one.
4. The first idle_add runs and tries to access destroyed widgets.

In addition, the IconTaskBarItem class had no protections at all for if the item was destroyed while the icon was scheduled to be rebuilt.

This commit also simplifies the code to use the new IdleDebounce class.