### PR TITLE
Fix workspace.focusedIndex could incorrectly be set to -1 in some cases.

### DIFF
--- a/src/layout/msWorkspace/msWorkspace.ts
+++ b/src/layout/msWorkspace/msWorkspace.ts
@@ -133,6 +133,9 @@ export class MsWorkspace extends WithSignals {
         this.destroyed = true;
     }
 
+    /** Index of the focused tileable.
+     * If there are no tileables in the workspace, this will be zero.
+     */
     get focusedIndex() {
         return this._state.focusedIndex;
     }
@@ -262,12 +265,9 @@ export class MsWorkspace extends WithSignals {
             this.focusedIndex > tileableIndex
         ) {
             this.focusedIndex--;
-        } else if (
-            this.focusedIndex === this.tileableList.length - 1 &&
-            this.tileableList.length > 1
-        ) {
-            this.focusedIndex--;
         }
+        this.focusedIndex = Math.max(0, Math.min(this.tileableList.length - 1, this.focusedIndex));
+
         await this.emitTileableListChangedOnce();
         // If there's no more focused msWindow on this workspace focus the last one
 


### PR DESCRIPTION
Previously, this could happen:

1. A user opens an application (e.g. VSCode) in an empty workspace.
2. The user open a second application (e.g. VSCode) in the same workspace using the search menu. This will set `insertedMsWindow`.
3. Both applications are killed (e.g. using `killall code`). Note that this must be done from a separate screen because if the focus changes in the first workspace then `insertedMsWindow` will be set to null again.
4. This can cause the window to be removed while it is the first window in the workspace, it is focused and insertMsWindow is not null.
5. focusedIndex will then be set to -1 and an exception will be thrown by the task bar later.