### PR TITLE
Improve window matching

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,7 +100,7 @@ function enable() {
                 Me.msWorkspaceManager.initState();
             }
             new MsMain();
-            Me.msWindowManager.handleExistingMetaWindow();
+            Me.msWindowManager.handleExistingMetaWindows();
             if (Main.layoutManager._startingUp) {
                 _startupPreparedId = Main.layoutManager.connect(
                     'startup-complete',

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -906,6 +906,7 @@ export class MsWindow extends Clutter.Actor {
         const dialog = this.lifecycleState.dialogs[idx];
         this.lifecycleState.dialogs.splice(idx, 1);
         this.remove_child(dialog.clone);
+        dialog.clone.destroy();
         metaWindow.msWindow = undefined;
     }
 

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -105,9 +105,6 @@ type MsWindowLifecycleState = {
     /** An MsWindow which will be destroyed soon unless another window or dialog opens */
     type: "waiting-for-destroy",
 } | {
-    /** An MsWindow in the process of getting destroyed */
-    type: "destroying",
-} | {
     /** A destroyed MsWindow. This cannot be used for anything anymore. */
     type: "destroyed",
 }
@@ -1062,7 +1059,6 @@ export class MsWindow extends Clutter.Actor {
                 this.destroy();
                 break;
             case "destroyed":
-            case "destroying":
                 break;
         }
     }

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -380,7 +380,7 @@ export class MsWindow extends Clutter.Actor {
             ? this.msWorkspace.monitor.y
             : workArea.y;
         if (this.lifecycleState.type === "window") {
-            // The dialogs are sorted because it affects their stacking order when displayed. We show the most recently created one on top.
+            // The dialogs are sorted because it affects their stacking order when displayed. We show the most recently interacted with window one on top.
             [...this.lifecycleState.dialogs]
                 .sort(
                     (firstDialog, secondDialog) =>

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -790,8 +790,8 @@ export class MsWindow extends Clutter.Actor {
                     this.updateWorkspaceAndMonitor(metaWindow);
                 }
             });
+            this.resizeMetaWindows();
         }
-        this.resizeMetaWindows();
     }
 
     async setWindow(metaWindow: MetaWindowWithMsProperties): Promise<void> {

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -973,18 +973,16 @@ export class MsWindow extends Clutter.Actor {
         assert(state.type == "window", "Expected the MsWindow to be in the 'window' state");
 
         const isMainMetaWindow = metaWindow === state.metaWindow;
-        const dialog = state.dialogs.find(
+        const dialog = state.dialogs.some(
             (dialog) => dialog.metaWindow === metaWindow
         );
         // If it's neither the MainMetaWindow or a Dialog we ignore, but this shouldn't happen
-        if (!isMainMetaWindow && dialog === undefined) {
+        if (!isMainMetaWindow && !dialog) {
             Me.log("Cannot find the window which was unmanaged");
             return;
         }
         if (dialog) {
-            state.dialogs.splice(state.dialogs.indexOf(dialog), 1);
-            this.remove_child(dialog.clone);
-            dialog.clone.destroy();
+            this.removeDialog(metaWindow);
         }
         if (isMainMetaWindow) {
             state.metaWindow = null;

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -1020,7 +1020,9 @@ export class MsWindow extends Clutter.Actor {
                 const dialogPromises = state.dialogs.map((dialog) => {
                     return new Promise<void>((resolve) => {
                         delete dialog.metaWindow.msWindow;
-                        dialog.metaWindow.destroying = true;
+                        // Make sure the window is not re-assigned to another MsWindow in the short duration
+                        // while it is being destroyed.
+                        dialog.metaWindow.handledByMaterialShell = false;
                         // TODO: When can this return false?
                         if (
                             dialog.metaWindow.get_compositor_private<Meta.WindowActor>()
@@ -1041,7 +1043,7 @@ export class MsWindow extends Clutter.Actor {
                         state.metaWindow.get_compositor_private<Meta.WindowActor>()
                     ) {
                         delete state.metaWindow.msWindow;
-                        state.metaWindow.destroying = true;
+                        state.metaWindow.handledByMaterialShell = false;
                         state.metaWindow.connect('unmanaged', (_) => {
                             resolve();
                         });

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -1051,11 +1051,15 @@ export class MsWindow extends Clutter.Actor {
                 if (this._persistent) {
                     // Persistent app placeholders cannot be closed
                 } else {
+                    // Note: This is here and not in _onDestroy because _onDestroy can sometimes be called when the workspace
+                    // has already been destroyed. TODO: This should be done in a better way.
+                    this.msWorkspace.removeMsWindow(this);
                     this.destroy();
                 }
                 break;
             }
             case "waiting-for-destroy":
+                this.msWorkspace.removeMsWindow(this);
                 this.destroy();
                 break;
             case "destroyed":
@@ -1118,7 +1122,6 @@ export class MsWindow extends Clutter.Actor {
 
     _onDestroy() {
         if (this.destroyId) this.disconnect(this.destroyId);
-        this.msWorkspace.removeMsWindow(this);
         this.unregisterOnMetaWindowSignals();
         this.lifecycleState = { type: "destroyed" };
     }

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -11,7 +11,7 @@ import {
     MetaWindowWithMsProperties,
 } from 'src/manager/msWindowManager';
 import { Rectangular } from 'src/types/mod';
-import { Async } from 'src/utils/async';
+import { Async, AsyncDebounce } from 'src/utils/async';
 /** Extension imports */
 import {
     Allocate,
@@ -25,8 +25,9 @@ import * as St from 'st';
 import { MsWorkspace } from './msWorkspace';
 import { PrimaryBorderEffect } from './tilingLayouts/baseResizeableTiling';
 import { App } from 'shell';
+import { assert, assertNotNull } from 'src/utils/assert';
+import { set_style_class } from 'src/utils/styling_utils';
 import { throttle } from 'src/utils';
-import { assert } from 'src/utils/assert';
 
 const isWayland = GLib.getenv('XDG_SESSION_TYPE').toLowerCase() === 'wayland';
 
@@ -34,12 +35,27 @@ export let isMsWindow = (obj: any): obj is MsWindow => {
     return obj instanceof MsWindow;
 };
 
+export function buildMetaWindowIdentifier(metaWindow: Meta.Window) {
+    return `${metaWindow.get_wm_class_instance()}-${metaWindow.get_pid()}-${metaWindow.get_stable_sequence()}`;
+}
+
 interface Dialog {
     metaWindow: MetaWindowWithMsProperties;
     clone: Clutter.Clone;
 }
+
+export interface MsWindowMatchingInfo {
+    appId: string;
+    /** Window title */
+    title: string | undefined,
+    pid: number | undefined,
+    wmClass: string | undefined,
+    /** Meta windows have a unique integer associated with them, this can be used to differentiate otherwise identical windows */
+    stableSeq: number | undefined,
+}
 export interface MsWindowState {
     appId: string;
+    matchingInfo: MsWindowMatchingInfo | undefined,
     metaWindowIdentifier: string | null;
     persistent: boolean | undefined;
     x: number;
@@ -50,11 +66,41 @@ export interface MsWindowState {
 
 export interface MsWindowConstructProps {
     app: App;
-    metaWindowIdentifier: string | null;
-    metaWindow: MetaWindowWithMsProperties | null;
     persistent?: boolean;
     initialAllocation?: Rectangular;
     msWorkspace: MsWorkspace;
+    lifecycleState: MsWindowLifecycleState,
+}
+
+type MsWindowLifecycleState = {
+    /** An MsWindow displaying an app with optional dialogs, or in rare cases only dialogs */
+    type: "window",
+    /** The main window. Note that this can be null if a dialog was opened and then the main window closed */
+    metaWindow: MetaWindowWithMsProperties | null,
+    metaWindowSignals: number[],
+    dialogs: Dialog[],
+} | {
+    /** An MsWindow showing a placeholder for a particular app */
+    type: "app-placeholder",
+    /** Desired properties of windows to be assigned to this MsWindow.
+     * This is in particular used when restoring from a persisted state.
+     * It allows meta windows to be associated with the correct MsWindows when restoring.
+     *
+     * These are not hard constraints, they only come into play if there are multiple alternatives
+     * for how meta windows could be associated with MsWindows.
+     */
+    matchingInfo: MsWindowMatchingInfo,
+    /** Set when an app has been launched and this window is expecting to be associated to that app */
+    waitingForAppSince: Date | undefined,
+} | {
+    /** An MsWindow which will be destroyed soon unless another window or dialog opens */
+    type: "waiting-for-destroy",
+} | {
+    /** An MsWindow in the process of getting destroyed */
+    type: "destroying",
+} | {
+    /** A destroyed MsWindow. This cannot be used for anything anymore. */
+    type: "destroyed",
 }
 
 @registerGObjectClass
@@ -77,18 +123,15 @@ export class MsWindow extends Clutter.Actor {
         },
     };
 
+    lifecycleState: MsWindowLifecycleState
+
     public app: App;
     _persistent: boolean | undefined;
-    dialogs: Dialog[];
-    metaWindowIdentifier: string | null;
     windowClone: Clutter.Clone;
     placeholder: AppPlaceholder;
     destroyId: number;
-    metaWindowSignals: number[];
     msContent: MsWindowContent;
     msWorkspace: MsWorkspace;
-    destroyed: boolean | undefined;
-    _metaWindow: MetaWindowWithMsProperties | null = null;
     focusEffects?: {
         dimmer?: Clutter.BrightnessContrastEffect;
         border?: PrimaryBorderEffect;
@@ -97,11 +140,10 @@ export class MsWindow extends Clutter.Actor {
 
     constructor({
         app,
-        metaWindowIdentifier,
-        metaWindow,
         persistent,
         initialAllocation,
         msWorkspace,
+        lifecycleState
     }: MsWindowConstructProps) {
         super({
             reactive: true,
@@ -111,16 +153,14 @@ export class MsWindow extends Clutter.Actor {
             height: initialAllocation ? initialAllocation.height || 0 : 0,
         });
 
+        this.lifecycleState = lifecycleState;
         this.app = app;
         this._persistent = persistent;
         this.msWorkspace = msWorkspace;
         this.updateMetaWindowPositionAndSizeThrottled = throttle(() => this.updateMetaWindowPositionAndSizeInternal(), 16);
 
-        this.dialogs = [];
-        this.metaWindowIdentifier = metaWindowIdentifier;
         this.windowClone = new Clutter.Clone();
         this.placeholder = new AppPlaceholder(this.app);
-        this.metaWindowSignals = [];
         this.placeholder.connect('activated', (_) => {
             this.emit('request-new-meta-window');
         });
@@ -137,17 +177,30 @@ export class MsWindow extends Clutter.Actor {
             clone: this.windowClone,
         });
         this.add_child(this.msContent);
-        if (metaWindow) {
-            this.setWindow(metaWindow);
-        }
 
         this.setMsWorkspace(msWorkspace);
     }
 
     get state(): MsWindowState {
+        const metaWindow = this.metaWindow;
         return {
-            appId: this.app.get_id(),
-            metaWindowIdentifier: this.metaWindowIdentifier,
+            appId: this.app.id,
+            // For compatibility we save a meta window identifier string.
+            // This is useful if the user decides to downgrade material-shell to a previous version.
+            metaWindowIdentifier: metaWindow !== null ? buildMetaWindowIdentifier(metaWindow) : null,
+            matchingInfo: this.lifecycleState.type == 'window' ? {
+                appId: this.app.id,
+                title: this.lifecycleState.metaWindow?.title,
+                pid: this.lifecycleState.metaWindow?.get_pid(),
+                wmClass: this.lifecycleState.metaWindow?.get_wm_class_instance(),
+                stableSeq: this.lifecycleState.metaWindow?.get_stable_sequence(),
+            } : {
+                appId: this.app.id,
+                title: undefined,
+                pid: undefined,
+                wmClass: undefined,
+                stableSeq: undefined,
+            },
             persistent: this._persistent,
             x: this.x,
             y: this.y,
@@ -156,19 +209,51 @@ export class MsWindow extends Clutter.Actor {
         };
     }
 
-    get metaWindow(): MetaWindowWithMsProperties {
-        return (
-            this._metaWindow ||
-            (this.dialogs &&
-                this.dialogs[this.dialogs.length - 1] &&
-                this.dialogs[this.dialogs.length - 1].metaWindow)
-        );
+    get metaWindow(): MetaWindowWithMsProperties | null {
+        const state = this.lifecycleState;
+        if (state.type == 'window') {
+            return (
+                state.metaWindow ||
+                (state.dialogs &&
+                    state.dialogs.length > 0 ? state.dialogs[state.dialogs.length - 1].metaWindow : null)
+            );
+        } else {
+            return null;
+        }
+    }
+
+    /** All meta windows represented by this MSWindow.
+     *
+     * This may be more than one window if dialogs are present, or it may be no windows if no app is launched for example.
+     */
+    get metaWindows(): MetaWindowWithMsProperties[] {
+        const state = this.lifecycleState;
+        if (state.type == 'window') {
+            const windows = state.dialogs.map(d => d.metaWindow);
+            if (state.metaWindow !== null) windows.push(state.metaWindow);
+            return windows;
+        } else {
+            return [];
+        }
+    }
+
+    /** A human-readable identifier for this window.
+     * This is not intended for anything other than debugging.
+     */
+    get windowIdentifier(): string {
+        const metaWindow = this.metaWindow;
+        if (metaWindow !== null) {
+            return buildMetaWindowIdentifier(metaWindow)
+        } else {
+            return `${this.app.id}-${this.lifecycleState.type}`;
+        }
     }
 
     get title() {
         if (!this.app) return '';
-        return this.metaWindow
-            ? this.metaWindow.get_title()
+        const metaWindow = this.metaWindow
+        return metaWindow
+            ? metaWindow.get_title()
             : this.app.get_name();
     }
 
@@ -252,7 +337,7 @@ export class MsWindow extends Clutter.Actor {
         });
     }
 
-    vfunc_allocate(box: Clutter.ActorBox, flags?: Clutter.AllocationFlags) {
+    override vfunc_allocate(box: Clutter.ActorBox, flags?: Clutter.AllocationFlags) {
         box.x1 = Math.round(box.x1);
         box.y1 = Math.round(box.y1);
         box.x2 = Math.round(box.x2);
@@ -277,32 +362,35 @@ export class MsWindow extends Clutter.Actor {
         const offsetY = monitorInFullScreen
             ? this.msWorkspace.monitor.y
             : workArea.y;
-        [...this.dialogs]
-            .sort(
-                (firstDialog, secondDialog) =>
-                    firstDialog.metaWindow.user_time -
-                    secondDialog.metaWindow.user_time
-            )
-            .forEach((dialog) => {
-                const dialogFrame = dialog.metaWindow.get_buffer_rect();
-                const x1 = dialogFrame.x - box.x1 - offsetX;
-                const x2 = x1 + dialogFrame.width;
-                const y1 = dialogFrame.y - box.y1 - offsetY;
-                const y2 = y1 + dialogFrame.height;
+        if (this.lifecycleState.type === "window") {
+            // The dialogs are sorted because it affects their stacking order when displayed. We show the most recently created one on top.
+            [...this.lifecycleState.dialogs]
+                .sort(
+                    (firstDialog, secondDialog) =>
+                        firstDialog.metaWindow.user_time -
+                        secondDialog.metaWindow.user_time
+                )
+                .forEach((dialog) => {
+                    const dialogFrame = dialog.metaWindow.get_buffer_rect();
+                    const x1 = dialogFrame.x - box.x1 - offsetX;
+                    const x2 = x1 + dialogFrame.width;
+                    const y1 = dialogFrame.y - box.y1 - offsetY;
+                    const y2 = y1 + dialogFrame.height;
 
-                const dialogBox = Clutter.ActorBox.new(x1, y1, x2, y2);
-                Allocate(dialog.clone, dialogBox, flags);
-            });
+                    const dialogBox = Clutter.ActorBox.new(x1, y1, x2, y2);
+                    Allocate(dialog.clone, dialogBox, flags);
+                });
+        }
     }
 
     // eslint-disable-next-line camelcase
-    set_position(x: number, y: number) {
+    override set_position(x: number, y: number) {
         if (this.followMetaWindow) return;
         super.set_position(x, y);
     }
 
     // eslint-disable-next-line camelcase
-    set_size(width: number, height: number) {
+    override set_size(width: number, height: number) {
         if (this.followMetaWindow) return;
         super.set_size(width, height);
     }
@@ -331,13 +419,14 @@ export class MsWindow extends Clutter.Actor {
     }
 
     private updateMetaWindowPositionAndSizeInternal() {
-        const metaWindow = this._metaWindow;
+        const state = this.lifecycleState;
+        if (state.type !== "window") return;
+        const metaWindow = state.metaWindow;
         const windowActor =
             metaWindow &&
             metaWindow.get_compositor_private<MetaWindowActorWithMsProperties>();
 
         if (
-            this.destroyed ||
             !windowActor ||
             !this.mapped ||
             this.width === 0 ||
@@ -552,21 +641,22 @@ export class MsWindow extends Clutter.Actor {
     }
 
     mimicMetaWindowPositionAndSize() {
-        if (!this.metaWindow || this.dragged) return;
+        const metaWindow = this.metaWindow;
+        if (!metaWindow || this.dragged) return;
         const workArea = Main.layoutManager.getWorkAreaForMonitor(
-            this.metaWindow.get_monitor()
+            metaWindow.get_monitor()
         );
-        const currentFrameRect = this.metaWindow.get_frame_rect();
+        const currentFrameRect = metaWindow.get_frame_rect();
         const newPosition = {
             x:
                 currentFrameRect.x -
-                (this.metaWindow.fullscreen
+                (metaWindow.fullscreen
                     ? this.msWorkspace.monitor.x
                     : workArea.x) -
                 this.msContent.x,
             y:
                 currentFrameRect.y -
-                (this.metaWindow.fullscreen
+                (metaWindow.fullscreen
                     ? this.msWorkspace.monitor.y
                     : workArea.y) -
                 this.msContent.y,
@@ -580,7 +670,8 @@ export class MsWindow extends Clutter.Actor {
     }
 
     resizeDialogs() {
-        this.dialogs.forEach((dialog) => {
+        if (this.lifecycleState.type !== "window") return;
+        this.lifecycleState.dialogs.forEach((dialog) => {
             const { metaWindow } = dialog;
             const frame = metaWindow.get_frame_rect();
             const workArea = Main.layoutManager.getWorkAreaForMonitor(
@@ -629,7 +720,7 @@ export class MsWindow extends Clutter.Actor {
     }
 
     resizeMetaWindows() {
-        if (this._metaWindow) {
+        if (this.lifecycleState.type == "window" && this.lifecycleState.metaWindow !== null) {
             this.followMetaWindow
                 ? this.mimicMetaWindowPositionAndSize()
                 : this.updateMetaWindowPositionAndSize();
@@ -638,57 +729,63 @@ export class MsWindow extends Clutter.Actor {
         this.resizeDialogs();
     }
 
-    registerOnMetaWindowSignals() {
-        if (!this.metaWindow) return;
-        this.metaWindowSignals.push(
-            this.metaWindow.connect('notify::title', (_) => {
+    registerOnMetaWindowSignals(metaWindow: MetaWindowWithMsProperties): number[] {
+        return [
+            metaWindow.connect('notify::title', (_) => {
                 this.emit('title-changed', this.title);
             }),
-            this.metaWindow.connect('position-changed', () => {
+            metaWindow.connect('position-changed', () => {
                 if (this.followMetaWindow) {
                     this.mimicMetaWindowPositionAndSize();
                 }
             }),
-            this.metaWindow.connect('size-changed', () => {
+            metaWindow.connect('size-changed', () => {
                 if (this.followMetaWindow) {
                     this.mimicMetaWindowPositionAndSize();
                 }
             }),
-            this.metaWindow.connect('notify::fullscreen', () => {
+            metaWindow.connect('notify::fullscreen', () => {
                 if (this.followMetaWindow) {
                     this.mimicMetaWindowPositionAndSize();
                 }
             })
-        );
+        ]
     }
 
     unregisterOnMetaWindowSignals() {
-        if (!this.metaWindow) return;
-        this.metaWindowSignals.forEach((signalId) => {
-            this.metaWindow.disconnect(signalId);
-        });
-        this.metaWindowSignals = [];
+        const state = this.lifecycleState;
+        if (state.type !== "window" || state.metaWindow === null) return;
+        for(const signalId of state.metaWindowSignals) {
+            state.metaWindow.disconnect(signalId);
+        }
+        state.metaWindowSignals = [];
     }
 
     setMsWorkspace(msWorkspace: MsWorkspace) {
         this.msWorkspace = msWorkspace;
-        [
-            ...this.dialogs.map((dialog) => dialog.metaWindow),
-            this.metaWindow,
-        ].forEach((metaWindow) => {
-            if (metaWindow) {
-                WindowUtils.updateTitleBarVisibility(metaWindow);
-                this.updateWorkspaceAndMonitor(metaWindow);
-            }
-        });
+        if (this.lifecycleState.type === "window") {
+            [
+                ...this.lifecycleState.dialogs.map((dialog) => dialog.metaWindow),
+                this.lifecycleState.metaWindow,
+            ].forEach((metaWindow) => {
+                if (metaWindow) {
+                    WindowUtils.updateTitleBarVisibility(metaWindow);
+                    this.updateWorkspaceAndMonitor(metaWindow);
+                }
+            });
+        }
         this.resizeMetaWindows();
     }
 
     async setWindow(metaWindow: MetaWindowWithMsProperties): Promise<void> {
-        this._metaWindow = metaWindow;
+        this.lifecycleState = {
+            type: "window",
+            metaWindow: metaWindow,
+            metaWindowSignals: this.registerOnMetaWindowSignals(metaWindow),
+            dialogs: [],
+        }
         metaWindow.msWindow = this;
 
-        this.registerOnMetaWindowSignals();
         await this.onMetaWindowActorExist(metaWindow);
         await this.onMetaWindowFirstFrameDrawn(metaWindow);
         this.updateWorkspaceAndMonitor(metaWindow);
@@ -701,7 +798,17 @@ export class MsWindow extends Clutter.Actor {
     unsetWindow() {
         this.unregisterOnMetaWindowSignals();
         this.reactive = true;
-        this._metaWindow = null;
+        this.lifecycleState = {
+            type: 'app-placeholder',
+            matchingInfo: {
+                appId: this.app.id,
+                title: undefined,
+                pid: undefined,
+                wmClass: undefined,
+                stableSeq: undefined,
+            },
+            waitingForAppSince: undefined,
+        };
         this.onMetaWindowsChanged();
     }
 
@@ -724,6 +831,19 @@ export class MsWindow extends Clutter.Actor {
     }
 
     addDialog(metaWindow: MetaWindowWithMsProperties): void {
+        if (this.lifecycleState.type === "app-placeholder") {
+            this.lifecycleState = {
+                type: "window",
+                metaWindow: null,
+                metaWindowSignals: [],
+                dialogs: []
+            }
+        }
+
+        if (this.lifecycleState.type !== "window") {
+            throw new Error(`Cannot add dialog to an MsWindow in the ${this.lifecycleState.type} state`);
+        };
+
         this.updateWorkspaceAndMonitor(metaWindow);
         const clone = new Clutter.Clone({
             source: metaWindow.get_compositor_private<Meta.WindowActor>(),
@@ -734,7 +854,7 @@ export class MsWindow extends Clutter.Actor {
             clone,
         };
         metaWindow.msWindow = this;
-        this.dialogs.push(dialog);
+        this.lifecycleState.dialogs.push(dialog);
         this.add_child(clone);
         this.resizeDialogs();
         this.onMetaWindowsChanged();
@@ -743,38 +863,21 @@ export class MsWindow extends Clutter.Actor {
         }
     }
 
-    removeDialog(dialog: Dialog): void {
-        this.dialogs.splice(this.dialogs.indexOf(dialog), 1);
-        this.remove_child(dialog.clone);
-        dialog.clone.destroy();
-    }
-
     async onMetaWindowsChanged(): Promise<void> {
-        if (this.metaWindow) {
-            this.metaWindowIdentifier =
-                Me.msWindowManager.buildMetaWindowIdentifier(this.metaWindow);
+        if (this.lifecycleState.type == "window") {
             this.reactive = false;
-            await this.onMetaWindowActorExist(this.metaWindow);
-            await this.onMetaWindowFirstFrameDrawn(this.metaWindow);
-            WindowUtils.updateTitleBarVisibility(this.metaWindow);
+            let metaWindow = assertNotNull(this.metaWindow);
+            await this.onMetaWindowActorExist(metaWindow);
+            await this.onMetaWindowFirstFrameDrawn(metaWindow);
+            WindowUtils.updateTitleBarVisibility(metaWindow);
             this.resizeMetaWindows();
-            if (!this._metaWindow) {
-                if (!this.msContent.has_style_class_name('surface-darker')) {
-                    this.msContent.add_style_class_name('surface-darker');
-                }
-            } else {
-                if (this.msContent.has_style_class_name('surface-darker')) {
-                    this.msContent.remove_style_class_name('surface-darker');
-                }
-            }
+            set_style_class(this.msContent, 'surface-darker', this.lifecycleState.metaWindow === null);
             if (this.placeholder.get_parent()) {
                 this.fadeOutPlaceholder();
             }
         } else {
             this.reactive = false;
-            if (this.msContent.has_style_class_name('surface-darker')) {
-                this.msContent.remove_style_class_name('surface-darker');
-            }
+            set_style_class(this.msContent, 'surface-darker', false);
             if (!this.placeholder.get_parent()) {
                 this.msContent.add_child(this.placeholder);
             }
@@ -783,9 +886,8 @@ export class MsWindow extends Clutter.Actor {
     }
 
     grab_key_focus(): void {
-        if (this.dialogs.length) {
-            this.onFocus();
-        }
+        // TODO: Seems a bit redundant to first focus the dialogs and then change focus to the main window (is that even desired?)
+        this.focusDialogs();
         if (!Me.msWindowManager.msFocusManager.requestFocus(this)) return;
         if (this.metaWindow) {
             this.metaWindow.activate(global.get_current_time());
@@ -794,9 +896,10 @@ export class MsWindow extends Clutter.Actor {
         }
     }
 
-    onFocus(): void {
-        if (this.dialogs.length) {
-            [...this.dialogs]
+    focusDialogs(): boolean {
+        let focused = false;
+        if (this.lifecycleState.type === 'window' && this.lifecycleState.dialogs) {
+            [...this.lifecycleState.dialogs]
                 .sort((firstDialog, secondDialog) => {
                     return (
                         firstDialog.metaWindow.user_time -
@@ -807,9 +910,11 @@ export class MsWindow extends Clutter.Actor {
                     this.set_child_above_sibling(dialog.clone, null);
                     if (index === array.length - 1) {
                         dialog.metaWindow.activate(global.get_current_time());
+                        focused = true;
                     }
                 });
         }
+        return focused;
     }
 
     /**
@@ -817,74 +922,110 @@ export class MsWindow extends Clutter.Actor {
      * @param {MetaWindow} metaWindow the MetaWindow currently unManaged
      */
     metaWindowUnManaged(metaWindow: MetaWindowWithMsProperties): void {
-        const isMainMetaWindow = metaWindow === this._metaWindow;
-        const dialog = this.dialogs.find(
+        const state = this.lifecycleState;
+        assert(state.type == "window", "Expected the MsWindow to be in the 'window' state");
+
+        const isMainMetaWindow = metaWindow === state.metaWindow;
+        const dialog = state.dialogs.find(
             (dialog) => dialog.metaWindow === metaWindow
         );
-        // If it's neither the MainMetaWindow or a Dialog we ignore but this shouldn't happen
+        // If it's neither the MainMetaWindow or a Dialog we ignore, but this shouldn't happen
         if (!isMainMetaWindow && dialog === undefined) {
+            Me.log("Cannot find the window which was unmanaged");
             return;
         }
         if (dialog) {
-            this.removeDialog(dialog);
+            state.dialogs.splice(state.dialogs.indexOf(dialog), 1);
+            this.remove_child(dialog.clone);
+            dialog.clone.destroy();
         }
         if (isMainMetaWindow) {
-            this._metaWindow = null;
+            state.metaWindow = null;
         }
 
-        // We check in an idle that closing dialog didn't popped a new window. If there is no new window we kill the msWindow
-        GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
-            if (!this.dialogs.length && !this._metaWindow) {
-                this.kill();
-            }
-            return GLib.SOURCE_REMOVE;
-        });
-    }
-
-    kill() {
-        const dialogPromises = this.dialogs.map((dialog) => {
-            return new Promise<void>((resolve) => {
-                delete dialog.metaWindow.msWindow;
-                if (
-                    dialog.metaWindow.get_compositor_private<Meta.WindowActor>()
-                ) {
-                    dialog.metaWindow.connect('unmanaged', (_) => {
-                        resolve();
-                    });
-                    dialog.metaWindow.delete(global.get_current_time());
-                }
-            });
-        });
-        const promise = new Promise<void>((resolve) => {
-            if (
-                this.metaWindow &&
-                this.metaWindow.get_compositor_private<Meta.WindowActor>()
-            ) {
-                delete this.metaWindow.msWindow;
-                this.metaWindow.connect('unmanaged', (_) => {
-                    resolve();
-                });
-                this.metaWindow.delete(global.get_current_time());
-            } else {
-                resolve();
-            }
-        });
-        Promise.all([...dialogPromises, promise]).then(() => {
+        if (state.metaWindow == null && state.dialogs.length == 0) {
             if (this._persistent) {
-                this.dialogs = [];
                 this.unsetWindow();
             } else {
-                this._metaWindow = null;
-                if (!this.destroyed) {
-                    this._onDestroy();
-                    this.msWorkspace.removeMsWindow(this);
-                    if (this.destroyId) this.disconnect(this.destroyId);
+                this.lifecycleState = { type: 'waiting-for-destroy' };
+
+                // We check in an idle that closing dialog didn't pop up a new window. If there is no new window we kill the msWindow
+                GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+                    if (this.lifecycleState.type === 'waiting-for-destroy') {
+                        this.kill();
+                    }
+                    return GLib.SOURCE_REMOVE;
+                });
+            }
+        }
+    }
+
+    async kill() {
+        const state = this.lifecycleState;
+
+        switch (state.type) {
+            case "window": {
+                if (this._persistent) {
+                    this.unsetWindow();
+                } else {
+                    this.lifecycleState = { type: "destroying" };
+                }
+
+                const dialogPromises = state.dialogs.map((dialog) => {
+                    return new Promise<void>((resolve) => {
+                        delete dialog.metaWindow.msWindow;
+                        // TODO: When can this return false?
+                        if (
+                            dialog.metaWindow.get_compositor_private<Meta.WindowActor>()
+                        ) {
+                            dialog.metaWindow.connect('unmanaged', (_) => {
+                                resolve();
+                            });
+                            dialog.metaWindow.delete(global.get_current_time());
+                        } else {
+                            resolve();
+                        }
+                    });
+                });
+
+                const promise = new Promise<void>((resolve) => {
+                    if (
+                        state.metaWindow &&
+                        state.metaWindow.get_compositor_private<Meta.WindowActor>()
+                    ) {
+                        delete state.metaWindow.msWindow;
+                        state.metaWindow.connect('unmanaged', (_) => {
+                            resolve();
+                        });
+                        state.metaWindow.delete(global.get_current_time());
+                    } else {
+                        resolve();
+                    }
+                });
+
+                await Promise.all([...dialogPromises, promise]);
+
+                if (!this._persistent) {
+                    assert(this.lifecycleState.type === "destroying", "Did not expect the lifecycle state to have changed");
                     this.destroy();
                 }
+                break;
             }
-        });
-
-        return promise;
+            case "app-placeholder": {
+                if (this._persistent) {
+                    // Persistent app placeholders cannot be closed
+                } else {
+                    this.destroy();
+                }
+                break;
+            }
+            case "waiting-for-destroy":
+                this.destroy();
+                break;
+            case "destroyed":
+            case "destroying":
+                break;
+        }
     }
 
     fadeOutPlaceholder() {
@@ -915,15 +1056,16 @@ export class MsWindow extends Clutter.Actor {
     }
 
     updateMetaWindowVisibility() {
-        if (this.metaWindow) {
+        const metaWindow = this.metaWindow;
+        if (metaWindow) {
             const shouldBeHidden =
                 !this.visible ||
                 this.get_parent() === null ||
                 Me.msWindowManager.msDndManager.dragInProgress;
-            if (shouldBeHidden && !this.metaWindow.minimized) {
-                this.metaWindow.minimize();
-            } else if (!shouldBeHidden && this.metaWindow.minimized) {
-                this.metaWindow.unminimize();
+            if (shouldBeHidden && !metaWindow.minimized) {
+                metaWindow.minimize();
+            } else if (!shouldBeHidden && metaWindow.minimized) {
+                metaWindow.unminimize();
             }
         }
     }
@@ -931,7 +1073,7 @@ export class MsWindow extends Clutter.Actor {
     toString() {
         // When MS function parameter logging is enabled, toString may be called on windows that have been destroyed.
         // So we need to guard against this. super.toString would otherwise try to access the destroyed C object.
-        if (this.destroyed) {
+        if (this.lifecycleState.type === "destroyed") {
             return `[destroyed MsWindow - ${this.app.get_name()}]`;
         }
 
@@ -940,8 +1082,10 @@ export class MsWindow extends Clutter.Actor {
     }
 
     _onDestroy() {
-        this.destroyed = true;
+        if (this.destroyId) this.disconnect(this.destroyId);
+        this.msWorkspace.removeMsWindow(this);
         this.unregisterOnMetaWindowSignals();
+        this.lifecycleState = { type: "destroyed" };
     }
 }
 
@@ -974,7 +1118,7 @@ export class MsWindowContent extends St.Widget {
         box = themeNode.get_content_box(box);
         const parent = this.get_parent();
         assert(parent instanceof MsWindow, "expected parent to be an MsWindow");
-        const metaWindow: MetaWindowWithMsProperties = parent.metaWindow;
+        const metaWindow = parent.metaWindow;
         if (metaWindow && metaWindow.firstFrameDrawn) {
             const windowFrameRect = metaWindow.get_frame_rect();
             const windowBufferRect = metaWindow.get_buffer_rect();

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -48,11 +48,11 @@ interface Dialog {
 export interface MsWindowMatchingInfo {
     appId: string;
     /** Window title */
-    title: string | undefined,
-    pid: number | undefined,
-    wmClass: string | undefined,
+    title: string | undefined;
+    pid: number | undefined;
+    wmClass: string | undefined;
     /** Meta windows have a unique integer associated with them, this can be used to differentiate otherwise identical windows */
-    stableSeq: number | undefined,
+    stableSeq: number | undefined;
 }
 export interface MsWindowState {
     appId: string;

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -232,15 +232,13 @@ export class MsWindow extends Clutter.Actor {
 
     get metaWindow(): MetaWindowWithMsProperties | null {
         const state = this.lifecycleState;
-        if (state.type == 'window') {
-            return (
-                state.metaWindow ||
-                (state.dialogs &&
-                    state.dialogs.length > 0 ? state.dialogs[state.dialogs.length - 1].metaWindow : null)
-            );
-        } else {
-            return null;
-        }
+        if (state.type !== 'window') return null;
+
+        return (
+            state.metaWindow ||
+            (state.dialogs &&
+                state.dialogs.length > 0 ? state.dialogs[state.dialogs.length - 1].metaWindow : null)
+        );
     }
 
     /** All meta windows represented by this MSWindow.
@@ -249,13 +247,11 @@ export class MsWindow extends Clutter.Actor {
      */
     get metaWindows(): MetaWindowWithMsProperties[] {
         const state = this.lifecycleState;
-        if (state.type == 'window') {
-            const windows = state.dialogs.map(d => d.metaWindow);
-            if (state.metaWindow !== null) windows.push(state.metaWindow);
-            return windows;
-        } else {
-            return [];
-        }
+        if (state.type !== 'window') return [];
+
+        const windows = state.dialogs.map(d => d.metaWindow);
+        if (state.metaWindow !== null) windows.push(state.metaWindow);
+        return windows;
     }
 
     /** A human-readable identifier for this window.

--- a/src/layout/msWorkspace/msWorkspace.ts
+++ b/src/layout/msWorkspace/msWorkspace.ts
@@ -217,9 +217,7 @@ export class MsWorkspace extends WithSignals {
     }
 
     get msWindowList() {
-        return Me.msWindowManager.msWindowList.filter((msWindow) => {
-            return msWindow.msWorkspace && msWindow.msWorkspace === this;
-        });
+        return this.tileableList.filter(isMsWindow);
     }
 
     get containFullscreenWindow() {

--- a/src/layout/msWorkspace/msWorkspace.ts
+++ b/src/layout/msWorkspace/msWorkspace.ts
@@ -44,7 +44,7 @@ export class MsWorkspace extends WithSignals {
     private _state: MsWorkspaceState;
     insertedMsWindow: MsWindow | null;
     appLauncher: MsApplicationLauncher;
-    tileableList: Tileable[];
+    tileableList: Tileable[] = [];
     msWorkspaceCategory: MsWorkspaceCategory;
     precedentIndex: number;
     msWorkspaceActor: MsWorkspaceActor;
@@ -95,7 +95,6 @@ export class MsWorkspace extends WithSignals {
         );
         this.precedentIndex = initialState.focusedIndex;
 
-        this.tileableList = [];
         this.msWorkspaceActor = new MsWorkspaceActor(this);
 
         // First add AppLauncher since windows are inserted before it otherwise the order is a mess.
@@ -188,7 +187,7 @@ export class MsWorkspace extends WithSignals {
         this._state.msWindowList = this.tileableList
             .filter(isMsWindow)
             .filter((msWindow) => {
-                return !msWindow.app.is_window_backed();
+                return !msWindow.app.is_window_backed() && (msWindow.lifecycleState.type === "app-placeholder" || msWindow.lifecycleState.type === "window");
             })
             .map((msWindow) => {
                 return msWindow.state;

--- a/src/layout/msWorkspace/tilingLayouts/float.ts
+++ b/src/layout/msWorkspace/tilingLayouts/float.ts
@@ -30,7 +30,10 @@ export class FloatLayout extends BaseTilingLayout<FloatLayoutState> {
     alterTileable(tileable: Tileable) {
         if (tileable instanceof MsWindow && tileable.metaWindow) {
             GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
-                WindowUtils.updateTitleBarVisibility(tileable.metaWindow);
+                // Need to check again because the metaWindow may have been removed here.
+                if (tileable.metaWindow) {
+                    WindowUtils.updateTitleBarVisibility(tileable.metaWindow);
+                }
                 tileable.mimicMetaWindowPositionAndSize();
                 tileable.msContent.clip_to_allocation = false;
                 return GLib.SOURCE_REMOVE;
@@ -50,7 +53,9 @@ export class FloatLayout extends BaseTilingLayout<FloatLayoutState> {
             tileable.msContent.clip_to_allocation = true;
 
             GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
-                WindowUtils.updateTitleBarVisibility(tileable.metaWindow);
+                if (tileable.metaWindow) {
+                    WindowUtils.updateTitleBarVisibility(tileable.metaWindow);
+                }
                 return GLib.SOURCE_REMOVE;
             });
         }

--- a/src/layout/verticalPanel/searchResultList.ts
+++ b/src/layout/verticalPanel/searchResultList.ts
@@ -469,11 +469,9 @@ export class SearchResultList extends St.BoxLayout {
                             );
                         if (app) {
                             if (app.can_open_new_window()) {
-                                const msWindow =
+                                const { msWindow } =
                                     Me.msWindowManager.createNewMsWindow(
-                                        app.id,
-                                        null,
-                                        null,
+                                        app,
                                         {
                                             msWorkspace:
                                                 Me.msWorkspaceManager.getActiveMsWorkspace(),
@@ -481,11 +479,9 @@ export class SearchResultList extends St.BoxLayout {
                                             insert: true,
                                         }
                                     );
-                                if (msWindow !== undefined) {
-                                    Me.msWindowManager.openAppForMsWindow(
-                                        msWindow
-                                    );
-                                }
+                                Me.msWindowManager.openAppForMsWindow(
+                                    msWindow
+                                );
                             } else {
                                 app.activate();
                             }

--- a/src/manager/msFocusManager.ts
+++ b/src/manager/msFocusManager.ts
@@ -96,7 +96,7 @@ export class MsFocusManager extends MsManager {
         if (!windowFocus || !windowFocus.msWindow) return;
 
         const msWindow = windowFocus.msWindow;
-        msWindow.onFocus();
+        msWindow.focusDialogs();
         this.setFocusToMsWindow(msWindow);
     }
 

--- a/src/manager/msWindowManager.ts
+++ b/src/manager/msWindowManager.ts
@@ -214,7 +214,6 @@ export class MsWindowManager extends MsManager {
         // Handle all non-dialog windows that haven't been associated with an MsWindow yet. Dialog windows are handled by assignDialogWindows
         const windowActors = actors.filter(
             (w) =>
-                !w.is_destroyed() &&
                 !handledMetaWindows.has(w.metaWindow) &&
                 !this.isMetaWindowDialog(w.metaWindow)
         );

--- a/src/manager/msWindowManager.ts
+++ b/src/manager/msWindowManager.ts
@@ -218,17 +218,14 @@ export class MsWindowManager extends MsManager {
                 !this.isMetaWindowDialog(w.metaWindow)
         );
 
+        const candidateMsWindows = this.msWindowList.filter(
+            (x) => x.lifecycleState.type === 'app-placeholder' || (x.lifecycleState.type === 'window' && now - x.lifecycleState.matchedAtTime.getTime() < MAX_WINDOW_REASSOCIATION_TIME_MS)
+        );
         const groupedMsWindowsByApp = groupBy(
-            this.msWindowList.filter(
-                (x) =>
-                    x.lifecycleState.type === 'app-placeholder' || (x.lifecycleState.type === 'window' && now - x.lifecycleState.matchedAtTime.getTime() < MAX_WINDOW_REASSOCIATION_TIME_MS)
-            ),
+            candidateMsWindows,
             (window) => {
-                if (window.lifecycleState.type === 'app-placeholder' || window.lifecycleState.type === 'window') {
-                    return window.lifecycleState.matchingInfo.appId;
-                } else {
-                    throw new Error("Unreachable");
-                }
+                assert(window.lifecycleState.type === 'app-placeholder' || window.lifecycleState.type === 'window', "unreachable");
+                return window.lifecycleState.matchingInfo.appId;
             }
         );
         const groupedMetaWindowsByApp = groupBy(

--- a/src/manager/msWindowManager.ts
+++ b/src/manager/msWindowManager.ts
@@ -30,10 +30,6 @@ export type MetaWindowWithMsProperties = Meta.Window & {
     handledByMaterialShell?: boolean;
     msWindow?: MsWindow;
     titleBarVisible?: boolean;
-    /** Set when we have started destroying the window, but it has not yet completed.
-     * Used to avoid re-assigning windows that have just been removed from an MsWindow that is being destroyed.
-     */
-    destroying?: true,
 };
 
 export type MetaWindowActorWithMsProperties = Meta.WindowActor & {
@@ -184,7 +180,7 @@ export class MsWindowManager extends MsManager {
     private async assignWindows() {
         // We capture the list of all actors at the beginning and don't care about any new ones until the
         // next time we start assigning windows.
-        const actors = global.get_window_actors().filter(x => !(x.metaWindow as MetaWindowWithMsProperties).destroying);
+        const actors = global.get_window_actors().filter(x => (x.metaWindow as MetaWindowWithMsProperties).handledByMaterialShell);
         // Assign all non-dialog windows first
         const windowsDone = this.assignNonDialogWindows(actors);
         // Assign the dialog windows to previously existing MsWindows that fits them.

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,4 +1,5 @@
 import * as GLib from 'glib';
+import { assert } from './assert';
 
 export class Async {
     static timeoutIdList = [] as number[];
@@ -23,6 +24,64 @@ export class Async {
     static clearAllPendingTimeout() {
         for (const timeoutId of this.timeoutIdList) {
             this.clearTimeoutId(timeoutId);
+        }
+    }
+}
+
+/** Debounces a given function */
+export class AsyncDebounce {
+    public delayMs: number;
+
+    private timeoutId: number | undefined;
+    private running: boolean = false;
+    private runAgain: boolean = false;
+    private readonly f: () => Promise<void>;
+
+    constructor(delayMs: number, f: () => Promise<void>) {
+        this.delayMs = delayMs;
+        this.f = f;
+    }
+
+    /** Call `f` in about `delayMs` milliseconds.
+     * If this function is called multiple times before `f` runs, `f` will still only be called once.
+     *
+     * If `schedule` is called while `f` is running (it is asynchronous) then `f` will be called again
+     * as soon as `f` has finished its current execution.
+     *
+     * See https://docs.gtk.org/glib/main-loop.html
+     */
+    schedule() {
+        if (this.running) {
+            this.runAgain = true;
+        } else if (this.timeoutId === undefined) {
+            this.timeoutId = GLib.timeout_add(
+                GLib.PRIORITY_DEFAULT,
+                this.delayMs,
+                () => {
+                    this.runInternal();
+                    return GLib.SOURCE_REMOVE;
+                }
+            );
+        } else {
+            // Already scheduled and not running. We can just sit back and wait.
+        }
+    }
+
+    private async runInternal() {
+        assert(
+            !this.running,
+            'Expected all other invocations to have finished'
+        );
+        this.running = true;
+        this.timeoutId = undefined;
+        try {
+            await this.f();
+        } finally {
+            this.running = false;
+            if (this.runAgain) {
+                this.runAgain = false;
+                this.schedule();
+            }
         }
     }
 }

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,5 +1,8 @@
 import * as GLib from 'glib';
 import { assert } from './assert';
+import { logAsyncException } from './log';
+
+const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 export class Async {
     static timeoutIdList = [] as number[];
@@ -58,7 +61,8 @@ export class AsyncDebounce {
                 GLib.PRIORITY_DEFAULT,
                 this.delayMs,
                 () => {
-                    this.runInternal();
+                    // Note: need to manually catch exceptions in async functions, otherwise they will not be logged
+                    this.runInternal().catch(logAsyncException);
                     return GLib.SOURCE_REMOVE;
                 }
             );

--- a/src/utils/group_by.ts
+++ b/src/utils/group_by.ts
@@ -1,0 +1,14 @@
+/** Groups the given items into a map by their keys */
+export function groupBy<T,K>(items: T[], key: (item: T)=>K): Map<K, T[]> {
+    let map = new Map<K,T[]>();
+    for (const item of items) {
+        const k = key(item);
+        let ls = map.get(k);
+        if (ls === undefined) {
+            ls = [];
+            map.set(k, ls);
+        }
+        ls.push(item);
+    }
+    return map;
+}

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,0 +1,13 @@
+const Me = imports.misc.extensionUtils.getCurrentExtension();
+
+/** Logs an exception from a promise.
+ * If a promise throws an unhandled exception it will not be logged automatically, so this method can be used to
+ * ensure any errors are logged.
+*/
+export function logAsyncException(e: any) {
+    if (e instanceof Error) {
+        Me.log(`\nException when running asynchronous function:\n${e}\n${e.stack}\n`);
+    } else {
+        Me.logWithStackTrace(`\nException when running asynchronous function: ${e}\n`);
+    }
+}

--- a/src/utils/styling_utils.ts
+++ b/src/utils/styling_utils.ts
@@ -1,0 +1,14 @@
+import { Widget } from "st";
+
+/** Sets whether the widget has the given style class */
+export function set_style_class(widget: Widget, style_class: string, enabled: boolean) {
+    if (enabled) {
+        if (!widget.has_style_class_name(style_class)) {
+            widget.add_style_class_name(style_class);
+        }
+    } else {
+        if (widget.has_style_class_name(style_class)) {
+            widget.remove_style_class_name(style_class);
+        }
+    }
+}

--- a/src/utils/weighted_matching.ts
+++ b/src/utils/weighted_matching.ts
@@ -1,0 +1,87 @@
+import { assert } from "./assert";
+
+/** Weighted matching.
+ * Matches N items on the "left" side with M items on the "right" side such that every item on the "left" side is part of exactly one match, and the total cost is minimized.
+ * 
+ * Takes an array `costs[N][M]` where costs[i][j] is the cost for assigning item i on the left hand side with item j on the right hand side.
+ * 
+ * Returns the minimum total cost for a valid assignment as well as the assignment indices.
+ * In the return value, `assignments[i] = j` indicates that item `i` on the lhs was assigned to item `j` on the rhs.
+ * 
+ * Requires N <= M since otherwise not all items on the lhs can be matched.
+ *
+ * This implements the Hungarian Algorithm.
+ * Source: KACTL: https://github.com/kth-competitive-programming/kactl/blob/main/content/graph/WeightedMatching.h
+ * 
+ * See https://en.wikipedia.org/wiki/Assignment_problem
+ * See https://en.wikipedia.org/wiki/Hungarian_algorithm
+ */
+export function weighted_matching(costs: number[][]): { cost: number, assignments: Int32Array } {
+    const INT_MAX = 2147483647;
+
+	if (costs.length == 0) return { cost: 0, assignments: new Int32Array() };
+	const n = costs.length + 1;
+    const m = costs[0].length + 1;
+	if (n > m) {
+		throw new Error("Expected n <= m, otherwise not all items on the left hand side can be assigned");
+	}
+    const u = new Int32Array(n);
+    const v = new Int32Array(m);
+    const p = new Int32Array(m);
+    const ans = new Int32Array(n-1);
+
+	// Temporary arrays per loop
+	let dist = new Int32Array(m);
+	let pre = new Int32Array(m);
+	let done = new Int32Array(m+1); // Emulates a boolean array
+
+	for (let i = 1; i < n; i++) {
+		p[0] = i;
+		let j0 = 0; // add "dummy" worker 0
+		dist.fill(INT_MAX);
+		pre.fill(-1);
+		done.fill(0);
+		do { // dijkstra
+			done[j0] = 1;
+			let i0 = p[j0], j1 = 0, delta = INT_MAX;
+			for (let j = 1; j < m; j++) {
+                if (done[j] === 0) {
+                    let cur = costs[i0 - 1][j - 1] - u[i0] - v[j];
+                    if (cur < dist[j]) {
+						dist[j] = cur;
+						pre[j] = j0;
+					}
+                    if (dist[j] < delta) {
+						delta = dist[j];
+						j1 = j;
+					}
+                }
+            }
+			for (let j = 0; j < m; j++) {
+				if (done[j] === 1) {
+					u[p[j]] += delta;
+					v[j] -= delta;
+				} else {
+					dist[j] -= delta;
+				}
+			}
+			j0 = j1;
+		} while (p[j0] !== 0);
+		while (j0 !== 0) { // update alternating path
+			const j1 = pre[j0];
+			p[j0] = p[j1];
+			j0 = j1;
+		}
+	}
+	for (let j = 1; j < m; j++) {
+        if (p[j] !== 0) {
+			ans[p[j] - 1] = j - 1;
+		}
+    }
+	return { cost: -v[0], assignments: ans }; // min cost
+}
+
+export function test_hungarian() {
+    assert(weighted_matching([[10, 20, 30], [20, 30, 30], [20, 20, 5]]).cost == 10 + 30 + 5, "");
+	assert(weighted_matching([[10, 20, 10000], [1, 2, 10000], [5, 3, 10000]]).cost == 10000 + 1 + 3, "");
+}

--- a/src/widget/msApplicationLauncher.ts
+++ b/src/widget/msApplicationLauncher.ts
@@ -101,20 +101,16 @@ export class MsApplicationLauncher extends St.Widget {
                 this.appListContainer.highlightButton(button);
             });
             button.connect('clicked', () => {
-                const msWindow = Me.msWindowManager.createNewMsWindow(
-                    app.id,
-                    null,
-                    null,
+                const { msWindow } = Me.msWindowManager.createNewMsWindow(
+                    app,
                     {
                         msWorkspace: this.msWorkspace,
                         focus: true,
                         insert: false,
                     }
                 );
-                if (msWindow) {
-                    Me.msWindowManager.openAppForMsWindow(msWindow);
-                    this.appListContainer.reset();
-                }
+                Me.msWindowManager.openAppForMsWindow(msWindow);
+                this.appListContainer.reset();
             });
             this.appListContainer.addAppButton(button);
         });


### PR DESCRIPTION
This PR rewrites a significant chunk of the window handling to improve the way meta windows are associated with MsWindows.

Previously, meta windows would be associated with MsWindows using a metaWindowIdentifier which was basically the wmClass, pid and the window number bundled into a single string. It was decently useful at matching windows when material shell was just restarted, however it lacked when it came to matching windows after the computer had been restarted. There were several problems:

* Only a complete match was used, which meant that if e.g. the window number had changed (which it would usually do if the application had been restarted) then matching was suboptimal.
* A greedy match was used. Which meant that good associations could be skipped due to the order in which windows were associated.
* Other useful info was not taken into account, such as window titles which are often very descriptive.
* The windows were only associated once, and then never re-assigned. This is suboptimal for applications that open many windows to e.g. restore all previously opened documents. These applications will often have non-descriptive window titles at the start, but once the documents have been loaded the window titles will change to be more descriptive.

This PR changes things so that:

* Partial matches are allowed. Different attributes have different weights, e.g. a process PID is a stronger indicator than the window number.
* A non-greedy match is used. This PR uses a weighted matching to find the window associations with the lowest total cost. This makes it invariant to the order in which the windows are associated.
* Window titles are taken into account now.
* Windows are allowed to be re-assigned for a short duration (3 seconds) to allow for the above mentioned use case.

This PR also changes the internal state of the MsWindow quite significantly. Now a lot of info is stored in the `lifecycleState` field which is a tagged union of different states the window can be in. This allows the code to be more strict and provide better guarantees about which fields make sense to access for different window states.

A number of race condition bugs have been fixed as part of this PR.