### PR TITLE
Window management fixes

### DIFF
--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -424,18 +424,22 @@ export class MsWindow extends Clutter.Actor {
     }
 
     getRelativeMetaWindowPosition(metaWindow: Meta.Window) {
-        const x = this.x;
-        const y = this.y;
+        if (this.dragged) {
+            const currentFrameRect = metaWindow.get_frame_rect();
+            return {
+                x: currentFrameRect.x,
+                y: currentFrameRect.y,
+            };
+        } else {
+            const workArea = Main.layoutManager.getWorkAreaForMonitor(
+                this.msWorkspace.monitor.index
+            );
 
-        const currentFrameRect = metaWindow.get_frame_rect();
-        const workArea = Main.layoutManager.getWorkAreaForMonitor(
-            this.msWorkspace.monitor.index
-        );
-
-        return {
-            x: this.dragged ? currentFrameRect.x : workArea.x + x,
-            y: this.dragged ? currentFrameRect.y : workArea.y + y,
-        };
+            return {
+                x: workArea.x + this.x,
+                y: workArea.y + this.y,
+            };
+        }
     }
 
     /*

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -562,7 +562,10 @@ export class MsWindow extends Clutter.Actor {
                 !shouldBeMaximizedVertically && metaWindow.maximized_vertically;
 
             const callback = () => {
-                if (shouldMaximizeVertically && shouldUnMaximizeVertically) {
+                if (
+                    shouldUnMaximizeHorizontally &&
+                    shouldUnMaximizeVertically
+                ) {
                     metaWindow.unmaximize(Meta.MaximizeFlags.BOTH);
                 } else if (shouldUnMaximizeHorizontally) {
                     metaWindow.unmaximize(Meta.MaximizeFlags.HORIZONTAL);

--- a/src/layout/msWorkspace/tilingLayouts/baseResizeableTiling.ts
+++ b/src/layout/msWorkspace/tilingLayouts/baseResizeableTiling.ts
@@ -223,13 +223,13 @@ export class BaseResizeableTilingLayout<
         });
     }
 
-    alterTileable(tileable: Tileable) {
+    initializeTileable(tileable: Tileable) {
         this.addUnFocusEffect(
             tileable,
             this.currentFocusEffect,
             tileable === this.msWorkspace.tileableFocused
         );
-        super.alterTileable(tileable);
+        super.initializeTileable(tileable);
     }
 
     restoreTileable(tileable: Tileable) {
@@ -442,44 +442,39 @@ export class PrimaryBorderEffect extends Clutter.Effect {
             this._pipeline = new Cogl.Pipeline(coglContext);
         }
 
-        this.color.init_from_4ub(
-            parseInt(Me.msThemeManager.primary.substring(1, 3), 16),
-            parseInt(Me.msThemeManager.primary.substring(3, 5), 16),
-            parseInt(Me.msThemeManager.primary.substring(5, 7), 16),
-            this.opacity * 255
-        );
-        this.color.premultiply();
-        this._pipeline.set_color(this.color);
+        if (this.color !== Me.msThemeManager.primaryColor) {
+            this.color = Me.msThemeManager.primaryColor;
+            const c = this.color.copy();
+            c.set_alpha_float(this.opacity);
+            c.premultiply();
+            this._pipeline.set_color(c);
+        }
 
         const alloc = actor.get_allocation_box();
         const width = 2;
+        const allocWidth = alloc.get_width();
+        const allocHeight = alloc.get_height();
 
         // clockwise order
+        framebuffer.draw_rectangle(this._pipeline, 0, 0, allocWidth, width);
         framebuffer.draw_rectangle(
             this._pipeline,
-            0,
-            0,
-            alloc.get_width(),
-            width
-        );
-        framebuffer.draw_rectangle(
-            this._pipeline,
-            alloc.get_width() - width,
+            allocWidth - width,
             width,
-            alloc.get_width(),
-            alloc.get_height()
+            allocWidth,
+            allocHeight
         );
         framebuffer.draw_rectangle(
             this._pipeline,
             0,
-            alloc.get_height(),
-            alloc.get_width() - width,
-            alloc.get_height() - width
+            allocHeight,
+            allocWidth - width,
+            allocHeight - width
         );
         framebuffer.draw_rectangle(
             this._pipeline,
             0,
-            alloc.get_height() - width,
+            allocHeight - width,
             width,
             width
         );

--- a/src/layout/msWorkspace/tilingLayouts/float.ts
+++ b/src/layout/msWorkspace/tilingLayouts/float.ts
@@ -27,7 +27,7 @@ export class FloatLayout extends BaseTilingLayout<FloatLayoutState> {
         this.windowsRestacked();
     }
 
-    alterTileable(tileable: Tileable) {
+    initializeTileable(tileable: Tileable) {
         if (tileable instanceof MsWindow && tileable.metaWindow) {
             GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
                 // Need to check again because the metaWindow may have been removed here.
@@ -45,7 +45,7 @@ export class FloatLayout extends BaseTilingLayout<FloatLayoutState> {
                 null
             );
         }
-        super.alterTileable(tileable);
+        super.initializeTileable(tileable);
     }
 
     restoreTileable(tileable: Tileable) {

--- a/src/layout/msWorkspace/tilingLayouts/maximize.ts
+++ b/src/layout/msWorkspace/tilingLayouts/maximize.ts
@@ -6,6 +6,7 @@ import * as Clutter from 'clutter';
 import { BaseTilingLayout } from 'src/layout/msWorkspace/tilingLayouts/baseTiling';
 import { registerGObjectClass } from 'src/utils/gjs';
 import { InfinityTo0, reparentActor } from 'src/utils/index';
+import { isNonNull } from 'src/utils/predicates';
 import { TranslationAnimator } from 'src/widget/translationAnimator';
 import { MsWorkspace, Tileable } from '../msWorkspace';
 
@@ -139,7 +140,7 @@ export class MaximizeLayout extends BaseTilingLayout<MaximizeLayoutState> {
         });
 
         this.translationAnimator.setTranslation(
-            [prevActor],
+            [prevActor].filter(isNonNull),
             [nextActor],
             indexOfNextActor > indexOfPrevActor ? 1 : -1
         );

--- a/src/layout/msWorkspace/tilingLayouts/maximize.ts
+++ b/src/layout/msWorkspace/tilingLayouts/maximize.ts
@@ -4,6 +4,7 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 import * as Clutter from 'clutter';
 /** Extension imports */
 import { BaseTilingLayout } from 'src/layout/msWorkspace/tilingLayouts/baseTiling';
+import { logAssert } from 'src/utils/assert';
 import { registerGObjectClass } from 'src/utils/gjs';
 import { InfinityTo0, reparentActor } from 'src/utils/index';
 import { isNonNull } from 'src/utils/predicates';
@@ -36,9 +37,12 @@ export class MaximizeLayout extends BaseTilingLayout<MaximizeLayoutState> {
     displayTileable(actor: Tileable) {
         if (this.currentDisplayed) {
             if (
-                this.tileableContainer
-                    .get_children()
-                    .includes(this.currentDisplayed.tileable)
+                logAssert(
+                    this.tileableContainer
+                        .get_children()
+                        .includes(this.currentDisplayed.tileable),
+                    'Expected the currently displayed tileable to be a child of the tileable container'
+                )
             ) {
                 this.tileableContainer.remove_child(
                     this.currentDisplayed.tileable
@@ -81,12 +85,13 @@ export class MaximizeLayout extends BaseTilingLayout<MaximizeLayoutState> {
         }
     }
 
-    alterTileable(tileable: Tileable) {
-        super.alterTileable(tileable);
+    override shouldBeVisible(tileable: Tileable): boolean {
+        return tileable === this.currentDisplayed?.tileable;
+    }
+
+    initializeTileable(tileable: Tileable) {
+        super.initializeTileable(tileable);
         tileable.visible = true;
-        if (this.tileableContainer.get_children().includes(tileable)) {
-            this.tileableContainer.remove_child(tileable);
-        }
         if (tileable === this.msWorkspace.tileableFocused) {
             this.displayTileable(tileable);
         }

--- a/src/layout/msWorkspace/tilingLayouts/split.ts
+++ b/src/layout/msWorkspace/tilingLayouts/split.ts
@@ -101,48 +101,42 @@ export class SplitLayout extends BaseResizeableTilingLayout<SplitLayoutState> {
 
     onFocusChanged(
         tileableFocused: Tileable,
-        oldTileableFocused: Tileable | null
+        _oldTileableFocused: Tileable | null
     ) {
-        if (this.activeTileableList.includes(tileableFocused)) {
-            this.activeTileableList.forEach((tileable) => {
-                this.setUnFocusEffect(
-                    tileable,
-                    this.currentFocusEffect,
-                    tileable === tileableFocused
-                );
-            });
-            return;
-        }
-
-        // TODO: What happens if newIndex=1 and oldIndex=2 and columns=3?
         const newIndex = this.msWorkspace.tileableList.indexOf(tileableFocused);
-        const oldIndex = this.msWorkspace.tileableList.indexOf(
-            oldTileableFocused as any
+        // Represents a slice from baseIndex to baseIndex + this._state.nbOfColumns (exclusive)
+        let baseIndex = this.baseIndex;
+        // Ensure the new tileable is visible
+        baseIndex = Math.max(baseIndex, newIndex - this._state.nbOfColumns + 1);
+        baseIndex = Math.min(baseIndex, newIndex);
+        // Ensure the slice does not go out of bounds
+        baseIndex = Math.min(
+            baseIndex,
+            this.msWorkspace.tileableList.length - this._state.nbOfColumns
         );
-        const oldTileableList = this.activeTileableList;
-        if (oldIndex < newIndex) {
-            this.activeTileableList = this.msWorkspace.tileableList.slice(
-                newIndex - this._state.nbOfColumns + 1,
-                newIndex + 1
-            );
-        } else {
-            this.activeTileableList = this.msWorkspace.tileableList.slice(
-                newIndex,
-                newIndex + this._state.nbOfColumns
-            );
-        }
-        this.baseIndex = this.msWorkspace.tileableList.indexOf(
-            this.activeTileableList[0]
-        );
+        baseIndex = Math.max(baseIndex, 0);
 
-        this.startTransition(oldTileableList, this.activeTileableList);
-        [...oldTileableList, ...this.activeTileableList].forEach((tileable) => {
+        const oldTileableList = this.activeTileableList;
+
+        if (baseIndex !== this.baseIndex) {
+            this.baseIndex = baseIndex;
+            this.activeTileableList = this.msWorkspace.tileableList.slice(
+                baseIndex,
+                baseIndex + this._state.nbOfColumns
+            );
+            this.startTransition(oldTileableList, this.activeTileableList);
+        }
+
+        for (const tileable of new Set([
+            ...oldTileableList,
+            ...this.activeTileableList,
+        ])) {
             this.setUnFocusEffect(
                 tileable,
                 this.currentFocusEffect,
                 tileable === tileableFocused
             );
-        });
+        }
     }
 
     showAppLauncher() {

--- a/src/layout/msWorkspace/tilingLayouts/split.ts
+++ b/src/layout/msWorkspace/tilingLayouts/split.ts
@@ -82,17 +82,20 @@ export class SplitLayout extends BaseResizeableTilingLayout<SplitLayoutState> {
     }
 
     refreshVisibleActors() {
-        this.msWorkspace.tileableList.forEach((tileable) => {
-            const willBeDisplay = this.activeTileableList.includes(tileable);
-            if (
-                willBeDisplay &&
-                tileable.get_parent() !== this.tileableContainer
-            ) {
-                reparentActor(tileable, this.tileableContainer);
-            } else if (!willBeDisplay && tileable.get_parent()) {
-                this.tileableContainer.remove_child(tileable);
+        // refreshVisibleActors will be called when the animation finishes
+        if (this.translationAnimator.animationInProgress) return;
+
+        for (const tileable of this.msWorkspace.tileableList) {
+            if (this.shouldBeVisible(tileable)) {
+                if (tileable.get_parent() !== this.tileableContainer) {
+                    reparentActor(tileable, this.tileableContainer);
+                }
+            } else {
+                if (tileable.get_parent() === this.tileableContainer) {
+                    this.tileableContainer.remove_child(tileable);
+                }
             }
-        });
+        }
         this.msWorkspace.refreshFocus();
     }
 

--- a/src/manager/msThemeManager.ts
+++ b/src/manager/msThemeManager.ts
@@ -1,4 +1,5 @@
 /** Gnome libs imports */
+import { Color } from 'cogl';
 import * as Gio from 'gio';
 import { byteArray } from 'gjs';
 import * as GLib from 'glib';
@@ -35,13 +36,26 @@ export const FocusEffectEnum = {
     BORDER: 2,
 };
 
+function parseCoglColor(color: string): Color {
+    const c = new Color();
+    c.init_from_4ub(
+        parseInt(color.substring(1, 3), 16),
+        parseInt(color.substring(3, 5), 16),
+        parseInt(color.substring(5, 7), 16),
+        255
+    );
+    return c;
+}
+
 export class MsThemeManager extends MsManager {
-    themeContext: any;
+    themeContext: St.ThemeContext;
     theme: any;
     themeSettings: Gio.Settings;
     themeFile: Gio.FilePrototype;
     themeValue: string;
     primary: string;
+    primaryColor: Color;
+
     constructor() {
         super();
         this.themeContext = St.ThemeContext.get_for_stage(global.stage);
@@ -52,6 +66,7 @@ export class MsThemeManager extends MsManager {
         );
         this.themeValue = this.themeSettings.get_string('theme');
         this.primary = this.themeSettings.get_string('primary-color');
+        this.primaryColor = parseCoglColor(this.primary);
 
         this.observe(this.themeContext, 'changed', () => {
             Me.log('theme changed');
@@ -70,6 +85,7 @@ export class MsThemeManager extends MsManager {
         });
         this.observe(this.themeSettings, 'changed::primary-color', (schema) => {
             this.primary = schema.get_string('primary-color');
+            this.primaryColor = parseCoglColor(this.primary);
             this.regenerateStylesheet();
         });
         this.observe(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -92,19 +92,19 @@ export function throttle<T extends any[], R, C>(
 }
 
 export const isParentOfActor = (
-    parent: Clutter.Actor,
+    parent: Clutter.Actor | null,
     actor: Clutter.Actor
 ) => {
-    if (!parent || !actor) {
+    if (!parent) {
         return false;
     }
-    let isParent = false;
-    let parentOfActor = actor;
-    while (parentOfActor.get_parent() && !isParent) {
-        isParent = parentOfActor === parent;
+    let parentOfActor: Clutter.Actor | null = actor;
+
+    while (parentOfActor !== null) {
+        if (parentOfActor === parent) return true;
         parentOfActor = parentOfActor.get_parent();
     }
-    return isParent;
+    return false;
 };
 
 export const reparentActor = (

--- a/src/widget/material/button.ts
+++ b/src/widget/material/button.ts
@@ -121,7 +121,7 @@ export class MatButton extends St.Widget {
     /**
      * Just the child width
      */
-    vfunc_get_preferred_width(forHeight: number) {
+    override vfunc_get_preferred_width(forHeight: number) {
         if (!this.child) return super.vfunc_get_preferred_width(forHeight);
         return this.child.vfunc_get_preferred_width(forHeight);
     }
@@ -129,12 +129,15 @@ export class MatButton extends St.Widget {
     /**
      * Just the child height
      */
-    vfunc_get_preferred_height(forWidth: number) {
+    override vfunc_get_preferred_height(forWidth: number) {
         if (!this.child) return super.vfunc_get_preferred_height(forWidth);
         return this.child.vfunc_get_preferred_height(forWidth);
     }
 
-    vfunc_allocate(box: Clutter.ActorBox, flags?: Clutter.AllocationFlags) {
+    override vfunc_allocate(
+        box: Clutter.ActorBox,
+        flags?: Clutter.AllocationFlags
+    ) {
         SetAllocation(this, box, flags);
         const themeNode = this.get_theme_node();
         const contentBox = themeNode.get_content_box(box);

--- a/src/widget/translationAnimator.ts
+++ b/src/widget/translationAnimator.ts
@@ -49,6 +49,12 @@ export class TranslationAnimator extends Clutter.Actor {
         this.add_actor(this.transitionContainer);
     }
 
+    tryRemoveActor(actor: Clutter.Actor) {
+        if (this.transitionContainer.get_children().includes(actor)) {
+            this.transitionContainer.remove_child(actor);
+        }
+    }
+
     /** Starts a transition.
      *
      * Note: The translation animator takes full control over the parenting of the actors until the animation is complete.

--- a/src/widget/translationAnimator.ts
+++ b/src/widget/translationAnimator.ts
@@ -49,25 +49,29 @@ export class TranslationAnimator extends Clutter.Actor {
         this.add_actor(this.transitionContainer);
     }
 
+    /** Starts a transition.
+     *
+     * Note: The translation animator takes full control over the parenting of the actors until the animation is complete.
+     * When calling this function the actors may be parented in arbitrary ways, they will be reparented to the proper state.
+     */
     setTranslation(
-        initialActors: (Clutter.Actor | null)[],
+        initialActors: Clutter.Actor[],
         enteringActors: Clutter.Actor[],
         direction: number
     ): void {
+        let translationY = this.transitionContainer.translation_y;
+        let translationX = this.transitionContainer.translation_x;
+
         if (this.animationInProgress) {
             this.transitionContainer.remove_all_transitions();
             this.animationInProgress = false;
 
             // Remove all clones outside visible area
             const visibleArea = {
-                x1: Math.abs(this.transitionContainer.translation_x),
-                x2:
-                    Math.abs(this.transitionContainer.translation_x) +
-                    this.width,
-                y1: Math.abs(this.transitionContainer.translation_y),
-                y2:
-                    Math.abs(this.transitionContainer.translation_y) +
-                    this.height,
+                x1: Math.abs(translationX),
+                x2: Math.abs(translationX) + this.width,
+                y1: Math.abs(translationY),
+                y2: Math.abs(translationY) + this.height,
             };
 
             // Foreach child check if it's in visible bound
@@ -76,8 +80,8 @@ export class TranslationAnimator extends Clutter.Actor {
                 if (this.vertical) {
                     if (allocationBox.y2 < visibleArea.y1) {
                         this.transitionContainer.remove_actor(actor);
-                        this.transitionContainer.translation_y =
-                            this.transitionContainer.translation_y +
+                        translationY =
+                            translationY +
                             InfinityTo0(allocationBox.get_height());
                     }
                     if (allocationBox.y1 > visibleArea.y2) {
@@ -86,8 +90,8 @@ export class TranslationAnimator extends Clutter.Actor {
                 } else {
                     if (allocationBox.x2 < visibleArea.x1) {
                         this.transitionContainer.remove_actor(actor);
-                        this.transitionContainer.translation_x =
-                            this.transitionContainer.translation_x +
+                        translationX =
+                            translationX +
                             InfinityTo0(allocationBox.get_width());
                     }
                     if (allocationBox.x1 > visibleArea.x2) {
@@ -95,32 +99,39 @@ export class TranslationAnimator extends Clutter.Actor {
                     }
                 }
             });
-        } else if (initialActors) {
-            initialActors.forEach((actor) => {
+
+            for (const actor of initialActors) {
+                const p = actor.get_parent();
+                if (p !== this.transitionContainer) {
+                    p.remove_child(actor);
+                }
+            }
+        } else {
+            for (const actor of initialActors) {
                 reparentActor(actor, this.transitionContainer);
-            });
+            }
         }
 
+        const children = this.transitionContainer.get_children();
         enteringActors.forEach((actor, index) => {
             // check if the next actor are already in transition
-            const nextActorFound = this.transitionContainer
-                .get_children()
-                .find((existingActor) => {
-                    return existingActor === actor;
-                });
+            const nextActorFound = children.includes(actor);
             //insert nextActor Clone at the top pile if direction is positive or at the end if negative
             if (!nextActorFound) {
                 reparentActor(actor, this.transitionContainer);
                 if (direction < 0) {
                     this.transitionContainer.set_child_at_index(actor, index);
                     if (this.vertical) {
-                        this.transitionContainer.translation_y -= actor.height;
+                        translationY -= actor.height;
                     } else {
-                        this.transitionContainer.translation_x -= actor.width;
+                        translationX -= actor.width;
                     }
                 }
             }
         });
+        this.transitionContainer.translation_y = translationY;
+        this.transitionContainer.translation_x = translationX;
+
         //This seem uncessary but it's help to the this.width calculation when the next actor is a placeholder
         this.transitionContainer.set_child_at_index(
             this.transitionContainer.get_child_at_index(0),
@@ -141,6 +152,7 @@ export class TranslationAnimator extends Clutter.Actor {
                 ? this.transitionContainer.height - this.height
                 : this.transitionContainer.width - this.width;
         }
+
         if (this.vertical) {
             transitionConfig.translation_y = -target;
         } else {


### PR DESCRIPTION
Maybe I should split this into multiple PRs... Let me know if it's hard to review. Might be easier to go commit by commit.

- Simplify MsWindow.getRelativeMetaWindowPosition
- Fix typo causing meta windows to not be unmaximized properly.
- Improve performance of drawing border effects.
- Make animations slightly longer if they move tileables over a long distance.
- Simplify split.refreshVisibleActors.
- Simplify split.onFocusChanged.
- Make layouts not unparent and re-parent tileables as often.
- Simplify isParentOfActor.
- Add override specifiers to button.
