### PR TITLE
Fix install script not automatically restarting gnome if there are multiple log in sessions.

### DIFF
--- a/scripts/install.py
+++ b/scripts/install.py
@@ -19,11 +19,12 @@ def printc(color: str, text: str):
     ''' Prints some text with a color '''
     print(f"{color}{text}{RESET}")
 
-# Tries to invoke a command line tool
-# Returns false if the program exited with a non-zero error code or if the program failed to be executed.
-
 
 def try_call(params):
+    '''
+    Tries to invoke a command line tool
+    Returns false if the program exited with a non-zero error code or if the program failed to be executed.
+    '''
     try:
         subprocess.check_call(params)
         return True

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -14,10 +14,9 @@ GREEN = "\33[32m"
 YELLOW = "\33[33m"
 RESET = "\33[0m"
 
-''' Prints some text with a color '''
-
 
 def printc(color: str, text: str):
+    ''' Prints some text with a color '''
     print(f"{color}{text}{RESET}")
 
 # Tries to invoke a command line tool


### PR DESCRIPTION
If a user for example opened a tty as a separate login session then the install script would fail to parse the output and it would think the user was running wayland.
The new script finds the currently active graphical session and gets the window manager type from that.
