### PR TITLE
Fix some eslint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,13 +5,7 @@ module.exports = {
     env: {
         es6: true,
     },
-    parserOptions: { project: ['./tsconfig.json'] },
-    extends: [
-        'eslint:recommended',
-        'plugin:@typescript-eslint/recommended',
-        'plugin:prettier/recommended',
-        'prettier',
-    ],
+    extends: ['eslint:recommended', 'plugin:prettier/recommended', 'prettier'],
     plugins: ['prettier', '@typescript-eslint'],
     rules: {
         'prettier/prettier': 'error',
@@ -32,6 +26,22 @@ module.exports = {
             },
         ],
     },
+    overrides: [
+        {
+            files: ['*.ts', '*.tsx'],
+
+            extends: [
+                'plugin:@typescript-eslint/recommended',
+                // 'plugin:@typescript-eslint/strict',
+                // 'plugin:@typescript-eslint/recommended-requiring-type-checking',
+            ],
+
+            parserOptions: {
+                project: ['./tsconfig.json'],
+                ecmaVersion: 2020,
+            },
+        },
+    ],
     globals: {
         ARGV: false,
         Debugger: false,
@@ -47,8 +57,5 @@ module.exports = {
         C_: false,
         N_: false,
         ngettext: false,
-    },
-    parserOptions: {
-        ecmaVersion: 2020,
     },
 };

--- a/@gi-types/clutter/index.d.ts
+++ b/@gi-types/clutter/index.d.ts
@@ -4036,14 +4036,14 @@ export class Actor<A = LayoutManager, B = Content>
     get_pivot_point(): [number | null, number | null];
     get_pivot_point_z(): number;
     get_position(): [number | null, number | null];
-    get_preferred_height(for_width: number): [number | null, number | null];
+    get_preferred_height(for_width: number): [number, number];
     get_preferred_size(): [
         number | null,
         number | null,
         number | null,
         number | null
     ];
-    get_preferred_width(for_height: number): [number | null, number | null];
+    get_preferred_width(for_height: number): [number, number];
     get_previous_sibling(): Actor;
     get_reactive(): boolean;
     get_request_mode(): RequestMode;

--- a/scripts/generate_types.py
+++ b/scripts/generate_types.py
@@ -23,6 +23,12 @@ for file in dir.glob("@gi-types/**/*.d.ts"):
         text = text.replace("child_type?: VariantType<C> | null,",
                             "child_type: VariantType<C>,")
 
+        # The return values can never be null, this is a bug in the gir file parsing
+        text = text.replace(
+            "get_preferred_width(for_height: number): [number | null, number | null];", "get_preferred_width(for_height: number): [number, number];")
+        text = text.replace(
+            "get_preferred_height(for_width: number): [number | null, number | null];", "get_preferred_height(for_width: number): [number, number];")
+
         # Clutter typedefs are incorrect, parents can definitely be null
         text = text.replace("get_parent(): Actor;", "get_parent(): Actor | null;")
     with open(file, "w") as f:

--- a/src/layout/main.ts
+++ b/src/layout/main.ts
@@ -655,14 +655,14 @@ export class PrimaryMonitorContainer extends MonitorContainer {
         const panelBox = new Clutter.ActorBox();
         const panelPosition = Me.msThemeManager.verticalPanelPosition;
         if (this.panel) {
-            const panelWidth = this.panel.get_preferred_width(-1)[1]!;
+            const panelWidth = this.panel.get_preferred_width(-1)[1];
             panelBox.x1 =
                 panelPosition === VerticalPanelPositionEnum.LEFT
                     ? box.x1
                     : box.x2 - panelWidth;
             panelBox.x2 = panelBox.x1 + panelWidth;
             panelBox.y1 = box.y1;
-            panelBox.y2 = this.panel.get_preferred_height(-1)[1]!;
+            panelBox.y2 = this.panel.get_preferred_height(-1)[1];
         }
 
         const msWorkspaceActorBox = new Clutter.ActorBox();

--- a/src/layout/main.ts
+++ b/src/layout/main.ts
@@ -346,11 +346,9 @@ export class MsMain extends St.Widget {
             Me.msWindowManager.msFocusManager.popModal(this);
         } else {
             this.overviewShown = true;
-            if (Main._findModal(this) === -1) {
-                Me.msWindowManager.msFocusManager.pushModal(this, {
-                    actionMode: Shell.ActionMode.OVERVIEW,
-                });
-            }
+            Me.msWindowManager.msFocusManager.pushModal(this, {
+                actionMode: Shell.ActionMode.OVERVIEW,
+            });
 
             const dimmerEffect = new Clutter.BrightnessContrastEffect({
                 name: 'dimmer',

--- a/src/layout/msWorkspace/horizontalPanel/horizontalPanel.ts
+++ b/src/layout/msWorkspace/horizontalPanel/horizontalPanel.ts
@@ -8,7 +8,6 @@ import { registerGObjectClass } from 'src/utils/gjs';
 import * as St from 'st';
 import { popupMenu as PopupMenu } from 'ui';
 import { MsWorkspace } from '../msWorkspace';
-const DND = imports.ui.dnd;
 
 /** Extension imports */
 const Me = imports.misc.extensionUtils.getCurrentExtension();
@@ -107,7 +106,7 @@ export class HorizontalPanel extends St.BoxLayout {
         const themeNode = this.get_theme_node();
         const contentBox = themeNode.get_content_box(box);
         const clockWidth = this.clockBin
-            ? this.clockBin.get_preferred_width(-1)[1]!
+            ? this.clockBin.get_preferred_width(-1)[1]
             : 0;
         const taskBarBox = new Clutter.ActorBox();
         taskBarBox.x1 = contentBox.x1;

--- a/src/layout/msWorkspace/horizontalPanel/layoutSwitcher.ts
+++ b/src/layout/msWorkspace/horizontalPanel/layoutSwitcher.ts
@@ -14,7 +14,6 @@ import { registerGObjectClass } from 'src/utils/gjs';
 import * as St from 'st';
 import { main as Main, popupMenu } from 'ui';
 import { MsWorkspace } from '../msWorkspace';
-const Animation = imports.ui.animation;
 
 /** Extension imports */
 const Me = imports.misc.extensionUtils.getCurrentExtension();

--- a/src/layout/msWorkspace/horizontalPanel/taskBar.ts
+++ b/src/layout/msWorkspace/horizontalPanel/taskBar.ts
@@ -616,14 +616,13 @@ export class TileableItem extends TaskBarItem {
             }
         }
     }
-    override vfunc_allocate(...args: [Clutter.ActorBox]) {
-        const box = args[0];
+    vfunc_allocate(box: Clutter.ActorBox, flags?: Clutter.AllocationFlags) {
         const height = box.get_height();
 
         if (!this.icon || this.lastHeight != height) {
             this.buildIconIdle.schedule(height);
         }
-        super.vfunc_allocate(...args);
+        super.vfunc_allocate(box);
     }
     _onDestroy() {
         this.buildIconIdle.cancel();
@@ -668,14 +667,13 @@ export class IconTaskBarItem extends TaskBarItem {
         return [_forHeight, _forHeight];
     }
 
-    override vfunc_allocate(...args: [Clutter.ActorBox]) {
-        const box = args[0];
+    vfunc_allocate(box: Clutter.ActorBox, flags?: Clutter.AllocationFlags) {
         const height = box.get_height() / 2;
 
         if (this.icon && this.icon.get_icon_size() != height) {
             this.buildIconIdle.schedule(height);
         }
-        super.vfunc_allocate(...args);
+        super.vfunc_allocate(box);
     }
 
     _onDestroy() {

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -32,10 +32,6 @@ import { PrimaryBorderEffect } from './tilingLayouts/baseResizeableTiling';
 
 const isWayland = GLib.getenv('XDG_SESSION_TYPE').toLowerCase() === 'wayland';
 
-export const isMsWindow = (obj: any): obj is MsWindow => {
-    return obj instanceof MsWindow;
-};
-
 export function buildMetaWindowIdentifier(metaWindow: Meta.Window) {
     return `${metaWindow.get_wm_class_instance()}-${metaWindow.get_pid()}-${metaWindow.get_stable_sequence()}`;
 }

--- a/src/layout/msWorkspace/msWorkspace.ts
+++ b/src/layout/msWorkspace/msWorkspace.ts
@@ -17,14 +17,13 @@ import { getSettings } from 'src/utils/settings';
 import { MsApplicationLauncher } from 'src/widget/msApplicationLauncher';
 import { layout, main as Main } from 'ui';
 import Monitor = layout.Monitor;
-const Signals = imports.signals;
 
 /** Extension imports */
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 export type Tileable = MsWindow | MsApplicationLauncher;
 
-function isMsWindow(argument: any): argument is MsWindow {
+function isMsWindow(argument: unknown): argument is MsWindow {
     return argument instanceof MsWindow;
 }
 

--- a/src/layout/msWorkspace/portion.ts
+++ b/src/layout/msWorkspace/portion.ts
@@ -1,8 +1,5 @@
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 /** Gnome libs imports */
 import { Rectangular } from 'src/types/mod';
-const Signals = imports.signals;
 
 const MIN_BASIS_RATIO = 0.1;
 

--- a/src/layout/msWorkspace/tilingLayouts/baseResizeableTiling.ts
+++ b/src/layout/msWorkspace/tilingLayouts/baseResizeableTiling.ts
@@ -283,23 +283,25 @@ export class BaseResizeableTilingLayout<
     addUnFocusEffect(tileable: Tileable, effect: number, focused: boolean) {
         if (!tileable || tileable.focusEffects) return;
         if (effect === FocusEffectEnum.DEFAULT) {
+            const dimmer = new Clutter.BrightnessContrastEffect({
+                name: 'dimmer',
+                brightness: focused
+                    ? Clutter.Color.new(127, 127, 127, 255)
+                    : Clutter.Color.new(100, 100, 100, 255),
+            });
             tileable.focusEffects = {
-                dimmer: new Clutter.BrightnessContrastEffect({
-                    name: 'dimmer',
-                    brightness: focused
-                        ? Clutter.Color.new(127, 127, 127, 255)
-                        : Clutter.Color.new(100, 100, 100, 255),
-                }),
+                dimmer,
             };
-            tileable.add_effect(tileable.focusEffects.dimmer!);
+            tileable.add_effect(dimmer);
         } else if (effect === FocusEffectEnum.BORDER) {
+            const border = new PrimaryBorderEffect({
+                name: 'border',
+                opacity: focused ? 1.0 : 0.0,
+            });
             tileable.focusEffects = {
-                border: new PrimaryBorderEffect({
-                    name: 'border',
-                    opacity: focused ? 1.0 : 0.0,
-                }),
+                border,
             };
-            tileable.add_effect(tileable.focusEffects.border!);
+            tileable.add_effect(border);
         }
     }
 

--- a/src/layout/msWorkspace/tilingLayouts/baseTiling.ts
+++ b/src/layout/msWorkspace/tilingLayouts/baseTiling.ts
@@ -27,7 +27,11 @@ export class BaseTilingLayout<
 
     constructor(msWorkspace: MsWorkspace, state: Partial<S> = {}) {
         super();
-        this._state = Object.assign({}, (this.constructor as any).state, state);
+        this._state = Object.assign(
+            {},
+            (this.constructor as unknown as { state: S }).state,
+            state
+        );
         this.icon = Gio.icon_new_for_string(
             `${Me.path}/assets/icons/tiling/${this._state.key}-symbolic.svg`
         );

--- a/src/layout/msWorkspace/tilingLayouts/custom/grid.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/grid.ts
@@ -2,9 +2,6 @@
 import { BaseResizeableTilingLayout } from 'src/layout/msWorkspace/tilingLayouts/baseResizeableTiling';
 import { registerGObjectClass } from 'src/utils/gjs';
 
-/** Extension imports */
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 @registerGObjectClass
 export class GridLayout extends BaseResizeableTilingLayout<{ key: 'grid' }> {
     static state = { key: 'grid' };

--- a/src/layout/msWorkspace/tilingLayouts/custom/half.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/half.ts
@@ -3,9 +3,6 @@ import * as Clutter from 'clutter';
 import { BaseResizeableTilingLayout } from 'src/layout/msWorkspace/tilingLayouts/baseResizeableTiling';
 import { registerGObjectClass } from 'src/utils/gjs';
 
-/** Extension imports */
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 @registerGObjectClass
 export class HalfLayoutBase<
     S extends { key: string }

--- a/src/layout/msWorkspace/tilingLayouts/custom/halfHorizontal.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/halfHorizontal.ts
@@ -2,9 +2,6 @@
 import { HalfLayoutBase } from 'src/layout/msWorkspace/tilingLayouts/custom/half';
 import { registerGObjectClass } from 'src/utils/gjs';
 
-/** Extension imports */
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 @registerGObjectClass
 export class HalfHorizontalLayout extends HalfLayoutBase<{
     key: 'half-horizontal';

--- a/src/layout/msWorkspace/tilingLayouts/custom/halfVertical.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/halfVertical.ts
@@ -2,9 +2,6 @@
 import { HalfLayoutBase } from 'src/layout/msWorkspace/tilingLayouts/custom/half';
 import { registerGObjectClass } from 'src/utils/gjs';
 
-/** Extension imports */
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 @registerGObjectClass
 export class HalfVerticalLayout extends HalfLayoutBase<{
     key: 'half-vertical';

--- a/src/layout/msWorkspace/tilingLayouts/custom/ratio.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/ratio.ts
@@ -3,9 +3,6 @@ import { BaseResizeableTilingLayout } from 'src/layout/msWorkspace/tilingLayouts
 import { registerGObjectClass } from 'src/utils/gjs';
 import { Portion } from '../../portion';
 
-/** Extension imports */
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 @registerGObjectClass
 export class RatioLayout extends BaseResizeableTilingLayout<{ key: 'ratio' }> {
     static state = { key: 'ratio' };

--- a/src/layout/msWorkspace/tilingLayouts/custom/simple.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/simple.ts
@@ -1,5 +1,3 @@
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 /** Gnome libs imports */
 import * as Clutter from 'clutter';
 /** Extension imports */

--- a/src/layout/msWorkspace/tilingLayouts/custom/simpleHorizontal.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/simpleHorizontal.ts
@@ -2,9 +2,6 @@
 import { SimpleLayoutBase } from 'src/layout/msWorkspace/tilingLayouts/custom/simple';
 import { registerGObjectClass } from 'src/utils/gjs';
 
-/** Extension imports */
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 @registerGObjectClass
 export class SimpleHorizontalLayout extends SimpleLayoutBase<{
     key: 'simple-horizontal';

--- a/src/layout/msWorkspace/tilingLayouts/custom/simpleVertical.ts
+++ b/src/layout/msWorkspace/tilingLayouts/custom/simpleVertical.ts
@@ -2,9 +2,6 @@
 import { SimpleLayoutBase } from 'src/layout/msWorkspace/tilingLayouts/custom/simple';
 import { registerGObjectClass } from 'src/utils/gjs';
 
-/** Extension imports */
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 @registerGObjectClass
 export class SimpleVerticalLayout extends SimpleLayoutBase<{
     key: 'simple-vertical';

--- a/src/layout/msWorkspace/tilingLayouts/float.ts
+++ b/src/layout/msWorkspace/tilingLayouts/float.ts
@@ -1,5 +1,3 @@
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 /** Gnome libs imports */
 import * as GLib from 'glib';
 import { MsWindow } from 'src/layout/msWorkspace/msWindow';

--- a/src/layout/msWorkspace/tilingLayouts/maximize.ts
+++ b/src/layout/msWorkspace/tilingLayouts/maximize.ts
@@ -1,5 +1,3 @@
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 /** Gnome libs imports */
 import * as Clutter from 'clutter';
 /** Extension imports */

--- a/src/layout/msWorkspace/tilingLayouts/split.ts
+++ b/src/layout/msWorkspace/tilingLayouts/split.ts
@@ -7,9 +7,6 @@ import { TranslationAnimator } from 'src/widget/translationAnimator';
 import { MsWorkspace, Tileable } from '../msWorkspace';
 import { Portion } from '../portion';
 
-/** Extension imports */
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 // TODO: Make this configurable
 // const WINDOW_SLIDE_TWEEN_TIME = 250;
 

--- a/src/layout/overview.ts
+++ b/src/layout/overview.ts
@@ -19,8 +19,6 @@ import {
 const ANIMATION_TIME = 250;
 const A11Y_SCHEMA = 'org.gnome.desktop.a11y.keyboard';
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 @registerGObjectClass
 class MsControlsManager extends St.Widget {
     _searchEntry: St.Entry;
@@ -213,7 +211,7 @@ class MsControlsManager extends St.Widget {
 @registerGObjectClass
 class OverviewActor extends St.BoxLayout {
     _controls: MsControlsManager;
-    _delegate: any;
+    _delegate: MsOverview | undefined = undefined;
 
     constructor() {
         super({

--- a/src/layout/verticalPanel/panelButton.ts
+++ b/src/layout/verticalPanel/panelButton.ts
@@ -39,10 +39,10 @@ export class MatPanelButton extends MatButton {
     }
 
     findMonitor() {
-        const [x, y] = this.get_transformed_position();
+        const [x, y] = this.get_transformed_position() as [number, number];
         return (
             global.display.get_monitor_index_for_rect(
-                new Meta.Rectangle({ x: x!, y: y!, width: 0, height: 0 })
+                new Meta.Rectangle({ x, y, width: 0, height: 0 })
             ) || global.display.get_current_monitor()
         );
     }

--- a/src/layout/verticalPanel/searchResultList.ts
+++ b/src/layout/verticalPanel/searchResultList.ts
@@ -11,7 +11,6 @@ import { MatButton } from 'src/widget/material/button';
 import * as St from 'st';
 import { appDisplay, remoteSearch } from 'ui';
 
-const DND = imports.ui.dnd;
 const ShellEntry = imports.ui.shellEntry;
 const ParentalControlsManager = imports.misc.parentalControlsManager;
 const SystemActions = imports.misc.systemActions;
@@ -73,7 +72,7 @@ export class SearchResultEntry extends MatButton {
         icon: St.Icon | null,
         title: string,
         description?: string,
-        withMenu?: boolean
+        _withMenu?: boolean
     ) {
         super({});
         if (icon) {
@@ -143,7 +142,6 @@ export class SearchResultList extends St.BoxLayout {
         icon_name: 'edit-clear-symbolic',
     });
     iconClickedId = 0;
-    resMetas: any;
     entrySelected: SearchResultEntry | null = null;
     constructor(searchEntry: St.Entry) {
         super({
@@ -157,8 +155,8 @@ export class SearchResultList extends St.BoxLayout {
         this.text.connect('text-changed', this.onTextChanged.bind(this));
         // Note: Clutter typedefs seem to be incorrect. According to the docs `ev` should be a Clutter.KeyEvent, but it actually seems to be a Clutter.Event.
         this.text.connect('key-press-event', this.onKeyPress.bind(this));
-        this.text.connect('key-focus-in', () => {});
-        this.text.connect('key-focus-out', () => {});
+        // this.text.connect('key-focus-in', () => {});
+        // this.text.connect('key-focus-out', () => {});
         this.searchEntry.connect('popup-menu', () => {
             /* if (!this._searchActive) return;
 
@@ -279,8 +277,6 @@ export class SearchResultList extends St.BoxLayout {
 
             return Clutter.EVENT_STOP;
         } else {
-            let arrowNext, nextDirection;
-
             if (symbol === Clutter.KEY_Tab) {
                 this.selectNext();
                 return Clutter.EVENT_STOP;
@@ -396,10 +392,6 @@ export class SearchResultList extends St.BoxLayout {
                 this.onSearchTimeout.bind(this)
             );
 
-        const escapedTerms = this.terms.map((term) =>
-            Shell.util_regex_escape(term)
-        );
-
         //this.emit('terms-changed');
     }
 
@@ -426,7 +418,6 @@ export class SearchResultList extends St.BoxLayout {
                 createIcon: (size: number) => St.Icon;
             }[]
         ) => {
-            this.resMetas = resMetas;
             let moreEntry: SearchResultEntry | null = null;
             //
             const extraResults: SearchResultEntry[] = [];

--- a/src/layout/verticalPanel/statusArea.ts
+++ b/src/layout/verticalPanel/statusArea.ts
@@ -23,8 +23,10 @@ export class MsStatusArea extends Clutter.Actor {
     leftBoxActors: Clutter.Actor[];
     rightBoxActors: Clutter.Actor[];
     dateMenu: dateMenu.DateMenuButton;
-    originalDateMenuBox: any;
-    msDateMenuBox?: MsDateMenuBox;
+    msDateMenuBox?: {
+        box: MsDateMenuBox;
+        originalDateMenuBox: Clutter.Actor;
+    };
     signalIds: {
         leftBoxActor: number;
         centerBoxActor: number;
@@ -58,10 +60,15 @@ export class MsStatusArea extends Clutter.Actor {
             this.msDateMenuBox === undefined,
             'date menu button has alreayd been verticalized'
         );
-        this.originalDateMenuBox = this.dateMenu._clockDisplay.get_parent();
-        this.dateMenu.remove_child(this.originalDateMenuBox);
-        this.msDateMenuBox = new MsDateMenuBox(this.dateMenu);
-        this.dateMenu.add_child(this.msDateMenuBox);
+        const originalDateMenuBox = assertNotNull(
+            this.dateMenu._clockDisplay.get_parent()
+        );
+        this.dateMenu.remove_child(originalDateMenuBox);
+        this.msDateMenuBox = {
+            box: new MsDateMenuBox(this.dateMenu),
+            originalDateMenuBox,
+        };
+        this.dateMenu.add_child(this.msDateMenuBox.box);
     }
 
     unVerticaliseDateMenuButton() {
@@ -69,9 +76,9 @@ export class MsStatusArea extends Clutter.Actor {
             this.msDateMenuBox !== undefined,
             "date menu button hasn't been verticalized"
         );
-        this.msDateMenuBox.destroy();
+        this.msDateMenuBox.box.destroy();
+        this.dateMenu.add_child(this.msDateMenuBox.originalDateMenuBox);
         delete this.msDateMenuBox;
-        this.dateMenu.add_child(this.originalDateMenuBox);
     }
 
     stealPanelActors() {

--- a/src/layout/verticalPanel/verticalPanel.ts
+++ b/src/layout/verticalPanel/verticalPanel.ts
@@ -14,8 +14,6 @@ import { main as Main, panel } from 'ui';
 import { SearchResultList } from './searchResultList';
 const Util = imports.misc.util;
 
-const SearchController = imports.ui.searchController;
-
 /** Extension imports */
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 

--- a/src/manager/msDndManager.ts
+++ b/src/manager/msDndManager.ts
@@ -19,15 +19,15 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 interface CurrentDrag {
     msWindow: MsWindow;
     originPointerAnchor: [number, number];
-    originalParent: any;
+    originalParent: Clutter.Actor;
 }
 
 export class MsDndManager extends MsManager {
     msWindowManager: MsWindowManager;
-    signalMap: Map<any, any>;
+    signalMap: Map<MsWindow, number>;
     dragInProgress: CurrentDrag | null;
     inputGrabber: InputGrabber;
-    throttledCheckUnderPointer: (this: any) => any;
+    throttledCheckUnderPointer: (this: MsDndManager) => void;
 
     constructor(msWindowManager: MsWindowManager) {
         super();
@@ -142,7 +142,7 @@ export class MsDndManager extends MsManager {
 
     startDrag(msWindow: MsWindow) {
         global.stage.add_child(this.inputGrabber);
-        const originalParent = msWindow.get_parent();
+        const originalParent = assertNotNull(msWindow.get_parent());
         msWindow.freezeAllocation();
         this.msWindowManager.msWindowList.forEach((aMsWindow) => {
             aMsWindow.updateMetaWindowVisibility();

--- a/src/manager/msManager.ts
+++ b/src/manager/msManager.ts
@@ -1,12 +1,12 @@
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 
 /** Gnome libs imports */
-const Signals = imports.signals;
 import * as Clutter from 'clutter';
+import { GObject } from 'src/types/mod';
 import { WithSignals } from 'src/utils/gjs';
 
 export interface Signal {
-    from: any;
+    from: WithSignals | GObject.Object;
     id: number;
 }
 
@@ -19,8 +19,9 @@ export class MsManager extends WithSignals {
     }
 
     observe(
-        subject: any,
+        subject: WithSignals | GObject.Object,
         property: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         callback: (...args: any[]) => void
     ) {
         const signal = {

--- a/src/manager/msNotificationManager.ts
+++ b/src/manager/msNotificationManager.ts
@@ -45,8 +45,8 @@ export class MsNotificationManager extends MsManager {
             let notifications: NotificationResponseItem[] = [];
             try {
                 notifications = JSON.parse(message.response_body.data);
-            } catch (e: any) {
-                global.log(`error unpack notification error ${e.toString()}`);
+            } catch (e: unknown) {
+                global.log(`error unpack notification error ${e}`);
                 return;
             }
             const source = new MsNotificationSource();

--- a/src/manager/msResizeManager.ts
+++ b/src/manager/msResizeManager.ts
@@ -41,7 +41,6 @@ interface CurrentResize {
 
 export class MsResizeManager extends MsManager {
     msWindowManager: MsWindowManager;
-    signalMap: Map<any, any>;
     inputResizer: InputResizer;
     msWorkspace: MsWorkspace | undefined;
     resizeInProgress: CurrentResize | null;
@@ -51,7 +50,6 @@ export class MsResizeManager extends MsManager {
         super();
 
         this.msWindowManager = msWindowManager;
-        this.signalMap = new Map();
         this.resizeInProgress = null;
         this.inputResizer = new InputResizer();
 
@@ -139,9 +137,12 @@ export class MsResizeManager extends MsManager {
         const { msWorkspaceActor } = this.resizeInProgress.msWorkspace;
 
         const [containerX, containerY] =
-            msWorkspaceActor.tileableContainer.get_transformed_position();
+            msWorkspaceActor.tileableContainer.get_transformed_position() as [
+                number,
+                number
+            ];
         const [globalX, globalY] = global.get_pointer();
-        return [globalX - containerX!, globalY - containerY!];
+        return [globalX - containerX, globalY - containerY];
     }
 
     getFirstPortionPositionAndSize(): Rectangular {

--- a/src/manager/msThemeManager.ts
+++ b/src/manager/msThemeManager.ts
@@ -4,6 +4,7 @@ import * as Gio from 'gio';
 import { byteArray } from 'gjs';
 import * as GLib from 'glib';
 import { MsManager } from 'src/manager/msManager';
+import { assertNotNull } from 'src/utils/assert';
 import { getSettings } from 'src/utils/settings';
 import { ShellVersionMatch } from 'src/utils/shellVersionMatch';
 import * as St from 'st';
@@ -49,7 +50,7 @@ function parseCoglColor(color: string): Color {
 
 export class MsThemeManager extends MsManager {
     themeContext: St.ThemeContext;
-    theme: any;
+    theme: St.Theme;
     themeSettings: Gio.Settings;
     themeFile: Gio.FilePrototype;
     themeValue: string;
@@ -214,7 +215,8 @@ export class MsThemeManager extends MsManager {
     async readFileContent(file: Gio.File) {
         return new Promise<string>((resolve, reject) => {
             file.load_contents_async(null, (obj, res) => {
-                const [success, contents] = obj!.load_contents_finish(res);
+                const [success, contents] =
+                    assertNotNull(obj).load_contents_finish(res);
                 if (success) {
                     //Read the binay content as string
                     const content = byteArray.toString(contents);
@@ -236,16 +238,16 @@ export class MsThemeManager extends MsManager {
                 GLib.PRIORITY_DEFAULT,
                 null,
                 (file, res) => {
-                    const stream = file!.replace_finish(res);
+                    const stream = assertNotNull(file).replace_finish(res);
 
                     stream.write_bytes_async(
                         contentBytes,
                         GLib.PRIORITY_DEFAULT,
                         null,
                         (ioStream, wRes) => {
-                            ioStream!.write_bytes_finish(wRes);
+                            assertNotNull(ioStream).write_bytes_finish(wRes);
                             stream.close(null);
-                            resolve(file!);
+                            resolve(assertNotNull(file));
                         }
                     );
                 }

--- a/src/manager/msWindowManager.ts
+++ b/src/manager/msWindowManager.ts
@@ -297,7 +297,7 @@ export class MsWindowManager extends MsManager {
                 costMatrix.push(costs);
             }
 
-            const { cost, assignments } = weighted_matching(costMatrix);
+            const { cost: _, assignments } = weighted_matching(costMatrix);
 
             // The meta window to be assigned to each MsWindow
             const msWindowAssignments = new Array<Meta.Window | null>(
@@ -445,14 +445,14 @@ export class MsWindowManager extends MsManager {
                 );
 
                 // We take the most recently focused msWindow
+                let bestTime = null;
                 for (const msWindow of samePidMsWindowList) {
-                    if (
-                        !msWindowFound ||
-                        (msWindow.metaWindow &&
-                            msWindowFound.metaWindow!.get_user_time() <
-                                msWindow.metaWindow.get_user_time())
-                    ) {
-                        msWindowFound = msWindow;
+                    if (msWindow.metaWindow) {
+                        const userTime = msWindow.metaWindow.get_user_time();
+                        if (bestTime == null || userTime > bestTime) {
+                            bestTime = userTime;
+                            msWindowFound = msWindow;
+                        }
                     }
                 }
             }
@@ -475,7 +475,7 @@ export class MsWindowManager extends MsManager {
                 for (const msWindow of sameAppMsWindowList) {
                     const score: [number, number] = [
                         msWindow.lifecycleState.type === 'window' ? 1 : 0,
-                        msWindow.metaWindow!.get_user_time(),
+                        msWindow.metaWindow?.get_user_time() ?? 0,
                     ];
                     if (
                         !msWindowFound ||

--- a/src/manager/stateManager.ts
+++ b/src/manager/stateManager.ts
@@ -10,9 +10,6 @@ import { getSettings } from 'src/utils/settings';
 const FileTest = GLib.FileTest;
 
 const REGISTRY_PATH = `${GLib.get_user_cache_dir()}/${Me.uuid}-state.json`;
-const REGISTRY_NEXT_PATH = `${GLib.get_user_cache_dir()}/${
-    Me.uuid
-}-state-next.json`;
 
 type StateDict = { [Key: string]: any };
 

--- a/src/manager/tooltipManager.ts
+++ b/src/manager/tooltipManager.ts
@@ -8,9 +8,6 @@ import { registerGObjectClass } from 'src/utils/gjs';
 import * as St from 'st';
 import { main as Main } from 'ui';
 
-/** Extension imports */
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 export class TooltipManager extends MsManager {
     constructor() {
         super();
@@ -155,36 +152,39 @@ export class MatTooltip extends St.Label {
     }
     vfunc_allocate(...args: [Clutter.ActorBox]) {
         const relativeActor = this.params.relativeActor || this.sourceActor;
-        const [stageX, stageY] = relativeActor.get_transformed_position();
+        const [stageX, stageY] = relativeActor.get_transformed_position() as [
+            number,
+            number
+        ];
         let x: number, y: number;
         switch (this.params.side) {
             case TooltipSide.LEFT:
-                x = stageX! - this.get_width();
+                x = stageX - this.get_width();
                 y =
-                    stageY! +
+                    stageY +
                     relativeActor.get_height() / 2 -
                     this.get_height() / 2;
                 break;
             case TooltipSide.TOP:
                 x =
-                    stageX! +
+                    stageX +
                     relativeActor.get_width() / 2 -
                     this.get_width() / 2;
-                y = stageY! - this.get_height();
+                y = stageY - this.get_height();
                 break;
             case TooltipSide.RIGHT:
-                x = stageX! + relativeActor.get_width();
+                x = stageX + relativeActor.get_width();
                 y =
-                    stageY! +
+                    stageY +
                     relativeActor.get_height() / 2 -
                     this.get_height() / 2;
                 break;
             case TooltipSide.BOTTOM:
                 x =
-                    stageX! +
+                    stageX +
                     relativeActor.get_width() / 2 -
                     this.get_width() / 2;
-                y = stageY! + relativeActor.get_height();
+                y = stageY + relativeActor.get_height();
                 break;
         }
         GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {

--- a/src/module/requiredSettingsModule.ts
+++ b/src/module/requiredSettingsModule.ts
@@ -4,9 +4,6 @@ import { Signal } from 'src/manager/msManager';
 import { assert } from 'src/utils/assert';
 import { getSettings } from 'src/utils/settings';
 
-/** Extension imports */
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-
 interface Setting {
     schema: string;
     key: string;

--- a/src/types/ui.d.ts
+++ b/src/types/ui.d.ts
@@ -25,6 +25,14 @@ declare module 'meta' {
     }
 }
 
+declare module 'clutter' {
+    // Seems to be part of gnome's version of clutter, but I can't find it in the offical docs or in the gir files.
+    class Grab {
+        // Necessary to disallow weird assignments. If this is not here typescript allows assigning e.g. booleans to fields of type 'Grab', which is weird.
+        private _grab: 'symbol';
+    }
+}
+
 declare module 'ui' {
     export namespace messageTray {
         interface NotificationParams {
@@ -123,6 +131,12 @@ declare module 'ui' {
         }
     }
 
+    type popModalPre42 = (actor: Clutter.Actor, timestamp?: number) => void;
+    type popModalPost42 = (grab: Clutter.Grab, timestamp?: number) => void;
+
+    type findModalPre42 = (actor: Actor) => number;
+    type findModalPost42 = (grab: Clutter.Grab) => number;
+
     export const main: {
         layoutManager: layout.LayoutManager;
         wm: windowManager.WindowManager;
@@ -139,9 +153,25 @@ declare module 'ui' {
                 options?: ModalOptions;
                 actionMode?: ActionMode;
             }
-        ): void;
-        popModal(actor: Actor): void;
-        _findModal(grab: any): number;
+        ):
+            | (Clutter.Grab &
+                  IntroducedInGnome<'42.0'> &
+                  RemovedInGnome<'never'>)
+            | (boolean & IntroducedInGnome<'ancient'> & RemovedInGnome<'42.0'>);
+        popModal:
+            | (popModalPost42 &
+                  IntroducedInGnome<'42.0'> &
+                  RemovedInGnome<'never'>)
+            | (popModalPre42 &
+                  IntroducedInGnome<'ancient'> &
+                  RemovedInGnome<'42.0'>);
+        _findModal:
+            | (findModalPost42 &
+                  IntroducedInGnome<'42.0'> &
+                  RemovedInGnome<'never'>)
+            | (findModalPre42 &
+                  IntroducedInGnome<'ancient'> &
+                  RemovedInGnome<'42.0'>);
         loadTheme(): void;
         reloadThemeResource(): void;
     };

--- a/src/utils/gjs.ts
+++ b/src/utils/gjs.ts
@@ -1,4 +1,3 @@
-const Me = imports.misc.extensionUtils.getCurrentExtension();
 import * as GObject from 'gobject';
 const Signals = imports.signals;
 
@@ -10,12 +9,14 @@ const Signals = imports.signals;
 /// ```
 export function registerGObjectClass<
     K,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     T extends { metaInfo?: GObject.MetaInfo; new (...params: any[]): K }
 >(target: T) {
     // Note that we use 'hasOwnProperty' because otherwise we would get inherited meta infos.
     // This would be bad because we would inherit the GObjectName too, which is supposed to be unique.
     if (Object.prototype.hasOwnProperty.call(target, 'metaInfo')) {
         return GObject.registerClass<K, T>(
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             target.metaInfo!,
             target
         ) as typeof target;
@@ -26,12 +27,13 @@ export function registerGObjectClass<
 
 export class WithSignals {
     // Note: these will be replaced by the addSignalMethods function
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function, @typescript-eslint/no-explicit-any
     emit(name: string, ...params: any[]): void {}
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
     connect(name: string, callback: (...params: any[]) => void): number {
         return 0;
     }
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
     disconnect(id: number): void {}
 }
 Signals.addSignalMethods(WithSignals.prototype);

--- a/src/utils/shellVersionMatch.ts
+++ b/src/utils/shellVersionMatch.ts
@@ -72,7 +72,7 @@ type PartitionedTuple<
 
 export type NeverRemoved = 'never';
 
-/// Use this to indicate that a type was introduced in a specific version of gnome
+/// Use this to indicate that a type was removed in a specific version of gnome
 /// Needs to be used together with `IntroducedInGnome`.
 /// You can use `RemovedInGnome<"never">` if the type is used in the latest version of gnome.
 export type RemovedInGnome<V extends VERSIONS[number] | NeverRemoved> = {


### PR DESCRIPTION
- Fix eslint config for non typescript files.
- Patch clutter typedefs.
- Fix various eslint warnings.
- Remove redundant check that didn't do anything since Gnome 42 anyway.
