### PR TITLE
fix Full screen bug #635

### DIFF
--- a/src/layout/main.ts
+++ b/src/layout/main.ts
@@ -434,6 +434,9 @@ export class MonitorContainer extends St.Widget {
         this.connect('destroy', () => {
             Me.msThemeManager.disconnect(panelSizeSignal);
             Me.msThemeManager.disconnect(horizontalPanelPositionSignal);
+            if (this.bgManager) {
+                this.bgManager.destroy();
+            }
         });
     }
 


### PR DESCRIPTION
When unplugged, monitor background wasn't removed and therefore was displayed above fullscreen window