### PR TITLE
Resize bottom icons in vertical panel with the panel.

### DIFF
--- a/src/layout/verticalPanel/verticalPanel.ts
+++ b/src/layout/verticalPanel/verticalPanel.ts
@@ -105,11 +105,11 @@ export class PanelContent extends St.BoxLayout {
         this.statusArea.disable();
     }
 
-    override vfunc_get_preferred_width(_forHeight: number): [number, number] {
-        return [
-            Me.msThemeManager.getPanelSize(Main.layoutManager.primaryIndex),
-            Me.msThemeManager.getPanelSize(Main.layoutManager.primaryIndex),
-        ];
+    override vfunc_get_preferred_width(_for_height: number): [number, number] {
+        const panelSize = Me.msThemeManager.getPanelSize(
+            Main.layoutManager.primaryIndex
+        );
+        return [panelSize, panelSize];
     }
 
     setIcon(icon: 'search' | 'close') {
@@ -277,6 +277,13 @@ export class MsPanel extends St.BoxLayout {
         this.panelContent.disable();
     }
 
+    override vfunc_get_preferred_width(_for_height: number): [number, number] {
+        const panelSize = Me.msThemeManager.getPanelSize(
+            Main.layoutManager.primaryIndex
+        );
+        return [panelSize, panelSize];
+    }
+
     toggle() {
         if (!this.isExpanded) {
             if (!Me.layout.panelsVisible) {
@@ -351,9 +358,7 @@ export class MsPanel extends St.BoxLayout {
                 onComplete: () => {
                     this.remove_child(this.searchContent);
                     this.remove_child(this.divider);
-                    this.width = Me.msThemeManager.getPanelSize(
-                        Main.layoutManager.primaryIndex
-                    );
+                    this.width = -1;
                     this.translation_x = 0;
                     if (!Me.layout.panelsVisible) {
                         this.hide();

--- a/src/styles/stylesheet.scss
+++ b/src/styles/stylesheet.scss
@@ -287,17 +287,10 @@ $panel-opacity: 0.876; // Don't change this value since it's dynamically changed
         min-height: 20px;
     }
     .system-status-icon {
-        height: 20px;
-        icon-size: 1.09em;
-        margin-top: 4px;
-        margin-bottom: 4px;
+        padding: 0px;
     }
     MsDateMenuBox {
         StIcon {
-            padding-top: 14px;
-            padding-bottom: 14px;
-            height: 20px;
-            width: 20px;
             .primary {
                 color: $color-primary;
             }

--- a/src/types/ui.d.ts
+++ b/src/types/ui.d.ts
@@ -193,6 +193,8 @@ declare module 'ui' {
     }
 
     export namespace panel {
+        let PANEL_ICON_SIZE: number;
+
         class Panel extends St.Widget {
             _leftBox: St.BoxLayout;
             _centerBox: St.BoxLayout;


### PR DESCRIPTION
Fixes #838 

Both system icons and icons added by the ubuntu-app-icons extensions (default on Ubuntu) will be resized when the panel resizes. The ubuntu app icons extension has limited reactivity, though, and a restart of gnome shell may be required to get things to be sized properly for some apps.

![image](https://user-images.githubusercontent.com/1144597/175659747-dd786807-4573-4a93-bbc3-03f999233c45.png)

Look with default panel size (40px) for reference:
![image](https://user-images.githubusercontent.com/1144597/175660975-7df80714-9caf-4d1e-aa63-d424c27abb84.png)

This PR also fixes a few other bugs:
* The side bar was not resized properly when changing the panel size setting.
* The icon order could get messed up sometimes. Now the order of the 3 groups (alerts, system-icons, custom icons) is always preserved.

Not tested on wayland.