### PR TITLE
Fix some invariants (parented=visible) not being preserved in some layouts.

### DIFF
--- a/src/layout/msWorkspace/tilingLayouts/baseResizeableTiling.ts
+++ b/src/layout/msWorkspace/tilingLayouts/baseResizeableTiling.ts
@@ -365,7 +365,7 @@ export class BaseResizeableTilingLayout<
         }
     }
 
-    onDestroy() {
+    override onDestroy() {
         if (this.borderContainer) {
             this.borderContainer.destroy();
         }

--- a/src/layout/msWorkspace/tilingLayouts/baseTiling.ts
+++ b/src/layout/msWorkspace/tilingLayouts/baseTiling.ts
@@ -122,8 +122,14 @@ export class BaseTilingLayout<
         ) {
             this.msWorkspace.appLauncher.hide();
         }
-        if (!tileable.get_parent() && this.shouldBeVisible(tileable)) {
-            this.tileableContainer.add_child(tileable);
+        if (this.shouldBeVisible(tileable)) {
+            if (!tileable.get_parent()) {
+                this.tileableContainer.add_child(tileable);
+            }
+        } else {
+            if (tileable.get_parent() === this.tileableContainer) {
+                this.tileableContainer.remove_child(tileable);
+            }
         }
     }
 


### PR DESCRIPTION
Previously, when using the maximize layout, all MsWindows were children of the workspace when the extension started. This wasn't really a problem per-say, but it's better to preserve invariants and avoid a ton of unnecessary overdraw (not sure how clutter handles that).

Also fixes some other issues like the destroy signal not being unsubscribed from during destroy.
This PR also removes some unnecessary reparentings happening if we tried to make the currently visible tileable visible again.