### PR TITLE
Optimize cursor and applauncher

### DIFF
--- a/src/layout/msWorkspace/tilingLayouts/baseResizeableTiling.ts
+++ b/src/layout/msWorkspace/tilingLayouts/baseResizeableTiling.ts
@@ -403,12 +403,12 @@ export class ResizableBorderActor extends St.Widget {
                     break;
                 }
                 case Clutter.EventType.ENTER:
-                    global.display.set_cursor(
+                    Me.msThemeManager.setCursor(
                         Meta.Cursor.MOVE_OR_RESIZE_WINDOW
                     );
                     break;
                 case Clutter.EventType.LEAVE:
-                    global.display.set_cursor(Meta.Cursor.DEFAULT);
+                    Me.msThemeManager.setCursor(Meta.Cursor.DEFAULT);
                     break;
             }
         });

--- a/src/manager/msDndManager.ts
+++ b/src/manager/msDndManager.ts
@@ -174,7 +174,7 @@ export class MsDndManager extends MsManager {
             )
         );
         this.msWindowManager.msFocusManager.pushModal(this.inputGrabber);
-        global.display.set_cursor(Meta.Cursor.DND_IN_DRAG);
+        Me.msThemeManager.setCursor(Meta.Cursor.DND_IN_DRAG);
     }
 
     endDrag() {
@@ -189,7 +189,7 @@ export class MsDndManager extends MsManager {
         this.msWindowManager.msWindowList.forEach((aMsWindow) => {
             aMsWindow.updateMetaWindowVisibility();
         });
-        global.display.set_cursor(Meta.Cursor.DEFAULT);
+        Me.msThemeManager.setCursor(Meta.Cursor.DEFAULT);
     }
 
     checkUnderThePointerRoutine() {

--- a/src/manager/msResizeManager.ts
+++ b/src/manager/msResizeManager.ts
@@ -169,7 +169,7 @@ export class MsResizeManager extends MsManager {
         global.stage.add_child(this.inputResizer);
         this.msWindowManager.msFocusManager.pushModal(this.inputResizer);
 
-        global.display.set_cursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
+        Me.msThemeManager.setCursor(Meta.Cursor.MOVE_OR_RESIZE_WINDOW);
     }
 
     updateResize() {
@@ -198,7 +198,7 @@ export class MsResizeManager extends MsManager {
         Me.stateManager.stateChanged();
 
         global.stage.remove_child(this.inputResizer);
-        global.display.set_cursor(Meta.Cursor.DEFAULT);
+        Me.msThemeManager.setCursor(Meta.Cursor.DEFAULT);
     }
 
     resizeTileable(

--- a/src/widget/material/button.ts
+++ b/src/widget/material/button.ts
@@ -76,10 +76,10 @@ export class MatButton extends St.Widget {
         this.add_action(clickAction);
 
         this.connect('enter-event', () => {
-            global.display.set_cursor(Meta.Cursor.POINTING_HAND);
+            Me.msThemeManager.setCursor(Meta.Cursor.POINTING_HAND);
         });
         this.connect('leave-event', () => {
-            global.display.set_cursor(Meta.Cursor.DEFAULT);
+            Me.msThemeManager.setCursor(Meta.Cursor.DEFAULT);
         });
     }
 


### PR DESCRIPTION
On button we do change the mouse cursor to the hand `pointer` when the mouse hover it but then we have to restore the default cursor when the leave the button.
Which lead when transitioning the cursor between two button to change the cursor 4x time from `pointer` to `pointer` which is a waste of resources.
This PR fix that by throttling the cursor change;
This PR also include some optimization of the applauncher hover highlight