### PR TITLE
Fix moving a window one workspace down would set focus incorrectly.

### DIFF
--- a/src/layout/msWorkspace/tilingLayouts/maximize.ts
+++ b/src/layout/msWorkspace/tilingLayouts/maximize.ts
@@ -77,7 +77,12 @@ export class MaximizeLayout extends BaseTilingLayout<MaximizeLayoutState> {
         // Even if this was the currently displayed actor,
         // the parent might be incorrect if we were just in an animation.
         reparentActor(actor, this.tileableContainer);
-        actor.grab_key_focus();
+
+        // Make sure the actor has focus, but only if this
+        // workspace is actually visible.
+        if (this.msWorkspace.isDisplayed()) {
+            actor.grab_key_focus();
+        }
     }
 
     showAppLauncher() {


### PR DESCRIPTION
Previously, it would play the animation and then immediately switch back to the previous workspace.