### PR TITLE
Support configurable install location and bare make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 extension = material-shell@papyelgringo
 extension_tool = gnome-shell-extension-tool
 
-.PHONY: schemas compile build_prod build_tasks update_git update install disable enable
+.PHONY: all schemas compile build_prod build_tasks update_git update install disable enable
+
+ifeq ($(XDG_DATA_HOME),)
+export XDG_DATA_HOME = $(HOME)/.local/share
+endif
+
+all: npm_dependencies compile
 
 schemas:
 	cp -r schemas dist

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -54,7 +54,8 @@ def install():
     os.chdir(package_dir)
 
     # Where gnome-shell extensions live
-    install_directory = os.path.expanduser("~/.local/share/gnome-shell/extensions")
+    data_home = os.environ.get('XDG_DATA_HOME') or "~/.local/share"
+    install_directory = os.path.expanduser(data_home + "/gnome-shell/extensions")
     # Under what name we want to install the extension as
     install_name = "material-shell@papyelgringo"
     install_path = os.path.join(install_directory, install_name)


### PR DESCRIPTION
My motivation for this is to support NixOS which installs into a
content-addressed directory layout and needs to be able to provide the
location of the XDG share (specific to the package)

Also it is more conventional to have the first target in make file do
the 'full build', then the standard build of `make && make install` will
work. I couldn't see a downside of adding this so I added an `all`
target. For my purposes this makes the packaging for NixOS more minimal
since I don't need to customise the standard builder (which is easy
enough to do, but this seemed like a good thing to have anyway).

Signed-off-by: Silas Davis <silas.davis@monax.io>