### PR TITLE
Add support for Gnome 43.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
     "shell-version": [
         "40",
         "41",
-        "42"
+        "42",
+        "43"
     ],
     "bindings": "org.gnome.shell.extensions.materialshell.bindings",
     "layouts": "org.gnome.shell.extensions.materialshell.layouts",

--- a/src/layout/verticalPanel/statusArea.ts
+++ b/src/layout/verticalPanel/statusArea.ts
@@ -9,7 +9,7 @@ import { assert, assertNotNull } from 'src/utils/assert';
 import { getExtensionSettings } from 'src/utils/extension_utils';
 import { registerGObjectClass } from 'src/utils/gjs';
 import { reparentActor } from 'src/utils/index';
-import { gnomeVersionGreaterOrEqualTo } from 'src/utils/shellVersionMatch';
+import { gnomeVersionGreaterOrEqualTo, compareVersions, parseVersion, gnomeVersionNumber } from 'src/utils/shellVersionMatch';
 import * as St from 'st';
 import { dateMenu, main as Main, panel } from 'ui';
 /** Extension imports */
@@ -197,7 +197,7 @@ export class MsStatusArea extends Clutter.Actor {
         // All icons actors should have a single child.
         const mainChild = actor.get_children()[0] as Clutter.Actor | undefined;
         if (mainChild !== undefined) {
-            if (mainChild instanceof panel.AggregateMenu) {
+            if (mainChild instanceof (compareVersions(gnomeVersionNumber, parseVersion('43.0')) >= 0 ? panel.QuickSettings : panel.AggregateMenu)) {
                 // This is the main system menu
                 return 1;
             } else if (mainChild instanceof dateMenu.DateMenuButton) {

--- a/src/types/ui.d.ts
+++ b/src/types/ui.d.ts
@@ -202,7 +202,9 @@ declare module 'ui' {
     export namespace panel {
         let PANEL_ICON_SIZE: number;
 
+        // QuickSettings replaces AggregateMenu starting with Gnome 43
         class AggregateMenu {}
+        class QuickSettings {}
 
         class Panel extends St.Widget {
             _leftBox: St.BoxLayout;

--- a/src/utils/shellVersionMatch.ts
+++ b/src/utils/shellVersionMatch.ts
@@ -94,7 +94,7 @@ export type IntroducedInGnome<V extends VERSIONS[number] | never> = {
 /// 'alpha', 'beta' and 'rc' components will be parsed to negative values
 /// which ensures that sorting works correctly.
 /// E.g. "43.alpha" will be parsed to [43,-3]
-function parseVersion(s: string): number[] {
+export function parseVersion(s: string): number[] {
     const components = s.split('.').map((x) => {
         if (x === 'alpha') return -3;
         if (x === 'beta') return -2;
@@ -109,7 +109,7 @@ function parseVersion(s: string): number[] {
 
 /// Compares to versions, returns -1 if lhs < rhs, 1 if lhs > rhs and 0 if lhs == rhs
 /// Lhs and rhs may be of different lengths, missing components will be assumed to be zero.
-function compareVersions(lhs: number[], rhs: number[]) {
+export function compareVersions(lhs: number[], rhs: number[]) {
     for (let i = 0; i < Math.max(lhs.length, rhs.length); i++) {
         const a = i < lhs.length ? lhs[i] : 0;
         const b = i < rhs.length ? rhs[i] : 0;
@@ -120,7 +120,7 @@ function compareVersions(lhs: number[], rhs: number[]) {
     return 0;
 }
 
-const gnomeVersionNumber = parseVersion(PACKAGE_VERSION);
+export const gnomeVersionNumber = parseVersion(PACKAGE_VERSION);
 
 /* exported ShellVersionMatch*/
 export function ShellVersionMatch(version: string) {


### PR DESCRIPTION
In Gnome 43, the system status menu was replaced by a new one with a different type. The type is used only once in material shell. This PR adds a version check around the usage to choose the correct type based on the gnome-shell version.

I have pretty much no experience with TypeScript yet, so there may be a better way of performing this check, maybe by using the `IntroducedInGnome` and `RemovedInGnome` types.