### PR TITLE
Replace the deprecated gnome-shell-extension-tool with gnome-extensions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 extension = material-shell@papyelgringo
-extension_tool = gnome-shell-extension-tool
+extension_tool = gnome-extensions
 
 .PHONY: schemas compile build_prod build_tasks update_git update install disable enable
 
@@ -22,10 +22,10 @@ dist:
 	mkdir dist
 
 disable:
-	$(extension_tool) -d $(extension)
+	$(extension_tool) disable $(extension)
 
 enable:
-	$(extension_tool) -e $(extension)
+	$(extension_tool) enable $(extension)
 
 npm_dependencies:
 	npm install


### PR DESCRIPTION
Since 2019-07-11 (before the release of the lowest compatible Gnome version 40), `gnome-shell-extension-tool` is deprecated in favor of `gnome-extensions` and was changed to be a wrapper for it. For the wrapping to work, `gnome-extensions` has to be already installed, thus this change should not break anything.

`scripts/install.py` also uses `gnome-extensions` already.