### PR TITLE
Set status icons to at least 16px

### DIFF
--- a/src/layout/verticalPanel/statusArea.ts
+++ b/src/layout/verticalPanel/statusArea.ts
@@ -262,8 +262,9 @@ export class MsStatusArea extends Clutter.Actor {
     }
 
     iconSize() {
-        return Math.round(
-            Me.msThemeManager.getPanelSizeNotScaled() * (16.0 / 48.0)
+        return Math.max(
+            16.0,
+            Math.round(Me.msThemeManager.getPanelSizeNotScaled() / 3)
         );
     }
 


### PR DESCRIPTION
No reason to be dynamic when the clock and other text are not. 16px always looks good and is readable. It was getting too small at panel-size 32, where it was 16px before ae2b52e0 and bb6742af.