### PR TITLE
Use 'quickSettings' instead of 'aggregateMenu' in Gnome 43 or later.

### DIFF
--- a/src/layout/verticalPanel/statusArea.ts
+++ b/src/layout/verticalPanel/statusArea.ts
@@ -369,7 +369,12 @@ export class MsStatusArea extends Clutter.Actor {
         this.restorePanelMenuSide();
         this.restorePanelActors();
         this.restoreAppIndicatorSettings();
-        this.gnomeShellPanel.statusArea.aggregateMenu.set_y_expand(true);
+
+        if (compareVersions(gnomeVersionNumber, parseVersion('43.0')) >= 0) {
+            this.gnomeShellPanel.statusArea.quickSettings.set_y_expand(true);
+        } else {
+            this.gnomeShellPanel.statusArea.aggregateMenu.set_y_expand(true);
+        }
     }
 }
 

--- a/src/types/ui.d.ts
+++ b/src/types/ui.d.ts
@@ -215,6 +215,7 @@ declare module 'ui' {
                 // TODO: Make all optional?
                 activities: any; // ActivitiesButton,
                 aggregateMenu: any; // AggregateMenu,
+                quickSettings: any; // QuickSettings,
                 appMenu: any; // AppMenuButton,
                 dateMenu: dateMenu.DateMenuButton;
                 a11y: any; // imports.ui.status.accessibility.ATIndicator,


### PR DESCRIPTION
This removes a reference to `aggregateMenu` that I missed in #884.