### PR TITLE
Allow filtering by window roles

### DIFF
--- a/schemas/layouts.gschema.xml
+++ b/schemas/layouts.gschema.xml
@@ -93,7 +93,7 @@
     <key name="roles-excluded" type="s">
       <default>''</default>
       <summary>Excluded window roles</summary>
-      <description>Comma separated list of window roles that will be ignored by Material shell. In order to get the class name for an active application: Press Alt + F2, type "lg" and click on the window tab.</description>
+      <description>Comma separated list of window roles that will be ignored by Material shell.</description>
     </key>
   </schema>
 </schemalist>

--- a/schemas/layouts.gschema.xml
+++ b/schemas/layouts.gschema.xml
@@ -90,5 +90,10 @@
       <summary>Excluded window classes</summary>
       <description>Comma separated list of window classes that will be ignored by Material shell. In order to get the class name for an active application: Press Alt + F2, type "lg" and click on the window tab.</description>
     </key>
+    <key name="roles-excluded" type="s">
+      <default>''</default>
+      <summary>Excluded window roles</summary>
+      <description>Comma separated list of window roles that will be ignored by Material shell. In order to get the class name for an active application: Press Alt + F2, type "lg" and click on the window tab.</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/manager/msWindowManager.ts
+++ b/src/manager/msWindowManager.ts
@@ -728,13 +728,14 @@ export class MsWindowManager extends MsManager {
         ) {
             return false;
         }
+        const windowRole = metaWindow.get_role();
         if (
-            metaWindow.get_role() !== '' &&
+            windowRole !== '' &&
             getSettings('layouts')
                 .get_string('roles-excluded')
                 .split(',')
                 .map((item) => item.trim())
-                .indexOf(metaWindow.get_role()) > -1
+                .indexOf(windowRole) !== -1
         ) {
             return false;
         }

--- a/src/manager/msWindowManager.ts
+++ b/src/manager/msWindowManager.ts
@@ -728,6 +728,17 @@ export class MsWindowManager extends MsManager {
         ) {
             return false;
         }
+        if (
+            metaWindow.get_role() !== '' &&
+            getSettings('layouts')
+                .get_string('role-excluded')
+                .split(',')
+                .map((item) => item.trim())
+                .indexOf(metaWindow.get_role()) > -1
+        ) {
+            return false;
+        }
+    
         if (metaWindow.above) {
             metaWindow.stick();
             return false;

--- a/src/manager/msWindowManager.ts
+++ b/src/manager/msWindowManager.ts
@@ -731,7 +731,7 @@ export class MsWindowManager extends MsManager {
         if (
             metaWindow.get_role() !== '' &&
             getSettings('layouts')
-                .get_string('role-excluded')
+                .get_string('roles-excluded')
                 .split(',')
                 .map((item) => item.trim())
                 .indexOf(metaWindow.get_role()) > -1

--- a/src/prefs/prefs-gtk3.ts.old
+++ b/src/prefs/prefs-gtk3.ts.old
@@ -106,6 +106,7 @@ export function buildGtk3() {
     layouts.addSetting('screen-gap', WidgetType.INT);
     layouts.addSetting('tween-time', WidgetType.DECIMAL);
     layouts.addSetting('windows-excluded', WidgetType.INPUT);
+    layouts.addSetting('roles-excluded', WidgetType.INPUT);
 
     settingsTab.addCategory(layouts);
 

--- a/src/prefs/prefs-gtk4.ts.old
+++ b/src/prefs/prefs-gtk4.ts.old
@@ -313,6 +313,7 @@ const PrefsWidget = GObject.registerClass(
             layouts.addSetting('screen-gap', WidgetType.INT);
             layouts.addSetting('tween-time', WidgetType.DECIMAL);
             layouts.addSetting('windows-excluded', WidgetType.INPUT);
+            layouts.addSetting('roles-excluded', WidgetType.INPUT);
             this._inner_box.append(layouts);
         }
     }

--- a/src/prefs/prefs.ts
+++ b/src/prefs/prefs.ts
@@ -496,6 +496,7 @@ class PrefsWidget extends Gtk.Box {
         layouts.addSetting('screen-gap', WidgetType.INT);
         layouts.addSetting('tween-time', WidgetType.DECIMAL);
         layouts.addSetting('windows-excluded', WidgetType.INPUT);
+        layouts.addSetting('roles-excluded', WidgetType.INPUT);
         this._settings_box.append(layouts);
     }
 }


### PR DESCRIPTION
I started using [fig](https://fig.io) and noticed some issues where material-shell would create a full window for the autocomplete popup. The suggested solution for WMs is to filter the window by its role (`autocomplete` in this case), but material-shell doesn't allow filtering by window role, so this PR adds that.

The only issue here is that I'm not sure what's a good way to discover the window roles as it doesn't seem like gnome inspector gives those details.