### PR TITLE
Support manually overriding the git commit hash for "metadata.json".

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ compile: dist schemas sass
 	npx tsc
 	npx tsc scripts/transpile.ts --outDir build && node build/transpile.js
 	npm run rollup-extension && npm run rollup-prefs
-	sed "s/{put_commit_there}/$(shell git rev-parse --short HEAD)/" metadata.json > dist/metadata.json
+	sed "s/{put_commit_there}/$$(test -z "$$GIT_COMMIT_HASH" && git rev-parse --short HEAD || echo "$$GIT_COMMIT_HASH")/" metadata.json > dist/metadata.json
 	cp -r assets dist/assets
 
 update_git:


### PR DESCRIPTION
The default for the "commit" field in "metadata.json" continues to be the git commit hash of the currently checked out git revision. If `make compile` is run in a directory created without git, e.g. by extracting an archive, the "commit" field has, by default, an empty string as a value. Both defaults can be overwritten with the value of the environment variable "GIT_COMMIT_HASH". This allows distro packagers to have an archive as the source and still provide the commit revision in the usual build process.