### PR TITLE
Try to blind fix 922 from logs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
         // only from the root of
         // your workspace
         "target": true,
-        "dist": true,
+        "dist": false,
         "build": true
     },
     "editor.codeActionsOnSave": {
@@ -20,5 +20,6 @@
         "source.fixAll": true,
         "source.organizeImports": true
     },
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -202,13 +202,13 @@ function showSplashScreens() {
         5000,
         () => {
             _splashscreenTimeoutId = 0;
-            hideSplashScreens();
+            return hideSplashScreens();
         }
     );
 }
 
 function hideSplashScreens() {
-    if (splashScreens.length < 1) return;
+    if (splashScreens.length < 1) return GLib.SOURCE_REMOVE;
     splashScreens.forEach((splashscreen) => {
         splashscreen.ease({
             opacity: 0,
@@ -222,4 +222,5 @@ function hideSplashScreens() {
     });
     splashScreens = [];
     splashscreenCalled = false;
+    return GLib.SOURCE_REMOVE;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,7 +132,10 @@ function loaded(disconnect: boolean) {
             Async.clearTimeoutId(_splashscreenTimeoutId);
             _splashscreenTimeoutId = 0;
         }
-        Async.addTimeout(GLib.PRIORITY_DEFAULT, 1000, hideSplashScreens);
+        Async.addTimeout(GLib.PRIORITY_DEFAULT, 1000, () => {
+            hideSplashScreens();
+            return GLib.SOURCE_REMOVE;
+        });
     }
     log('--------------------');
     log('END EXTENSION LOADED');
@@ -202,7 +205,8 @@ function showSplashScreens() {
         5000,
         () => {
             _splashscreenTimeoutId = 0;
-            return hideSplashScreens();
+            hideSplashScreens();
+            return GLib.SOURCE_REMOVE;
         }
     );
 }
@@ -222,5 +226,4 @@ function hideSplashScreens() {
     });
     splashScreens = [];
     splashscreenCalled = false;
-    return GLib.SOURCE_REMOVE;
 }

--- a/src/layout/msWorkspace/horizontalPanel/taskBar.ts
+++ b/src/layout/msWorkspace/horizontalPanel/taskBar.ts
@@ -289,6 +289,10 @@ export class TaskActiveIndicator extends St.Widget {
             scale_x: 1,
             duration: 250,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            onStopped: () => {
+                this.translation_x = 0;
+                this.scaleX = 1;
+            },
         });
     }
     vfunc_allocate(...args: [Clutter.ActorBox]) {

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -1016,7 +1016,6 @@ export class MsWindow extends Clutter.Actor {
                 // If the window is not drawn yet, the setWindow function must still be running.
                 // Most likely a dialog was added before the window was drawn.
                 // If the window eventually gets drawn, the setWindow function will call onMetaWindowsChanged again.
-                Me.logFocus('CACA CACA CACA CACA CACA');
             }
             set_style_class(
                 this.msContent,

--- a/src/layout/msWorkspace/msWindow.ts
+++ b/src/layout/msWorkspace/msWindow.ts
@@ -135,7 +135,7 @@ function isWindowContentInteresting(metaWindow: MetaWindowWithMsProperties) {
         return true;
     }
 
-    return SOURCE_CONTINUE;
+    return false;
 }
 
 @registerGObjectClass
@@ -333,6 +333,7 @@ export class MsWindow extends Clutter.Actor {
                         reject
                     );
                 }
+                return GLib.SOURCE_REMOVE;
             });
         } else {
             reject();
@@ -1015,6 +1016,7 @@ export class MsWindow extends Clutter.Actor {
                 // If the window is not drawn yet, the setWindow function must still be running.
                 // Most likely a dialog was added before the window was drawn.
                 // If the window eventually gets drawn, the setWindow function will call onMetaWindowsChanged again.
+                Me.logFocus('CACA CACA CACA CACA CACA');
             }
             set_style_class(
                 this.msContent,
@@ -1198,12 +1200,12 @@ export class MsWindow extends Clutter.Actor {
             }
             this.placeholder.reset();
         };
-
         this.placeholder.ease({
             opacity: 0,
             duration: 250,
             mode: Clutter.AnimationMode.EASE_OUT_CUBIC,
-            onComplete,
+            // We use onStopped instead of onComplete because we want to remove the placeholder even if the transition has been interrupted
+            onStopped: onComplete,
         });
     }
 

--- a/src/layout/verticalPanel/searchResultList.ts
+++ b/src/layout/verticalPanel/searchResultList.ts
@@ -293,6 +293,7 @@ export class SearchResultList extends St.BoxLayout {
     private onSearchTimeout() {
         this.searchTimeoutId = 0;
         this.doSearch();
+        return GLib.SOURCE_REMOVE;
     }
 
     private searchCancelled() {

--- a/src/manager/msDndManager.ts
+++ b/src/manager/msDndManager.ts
@@ -197,6 +197,7 @@ export class MsDndManager extends MsManager {
         this.throttledCheckUnderPointer();
         Async.addTimeout(GLib.PRIORITY_DEFAULT, 100, () => {
             this.checkUnderThePointerRoutine();
+            return GLib.SOURCE_REMOVE;
         });
     }
 

--- a/src/manager/msFocusManager.ts
+++ b/src/manager/msFocusManager.ts
@@ -47,6 +47,7 @@ export class MsFocusManager extends MsManager {
                 this.focusProtected = true;
                 Async.addTimeout(GLib.PRIORITY_DEFAULT, 100, () => {
                     delete this.focusProtected;
+                    return GLib.SOURCE_REMOVE;
                 });
             }
         );

--- a/src/manager/tooltipManager.ts
+++ b/src/manager/tooltipManager.ts
@@ -51,6 +51,7 @@ export class TooltipManager extends MsManager {
                 if (!left) {
                     tooltip = this.createTooltip(actor, params);
                 }
+                return GLib.SOURCE_REMOVE;
             });
         };
         this.observe(actor, 'enter-event', tooltipCallback);

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -7,11 +7,13 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 export class Async {
     static timeoutIdList = [] as number[];
 
-    static addTimeout(priority: number, interval: number, func: () => void) {
+    static addTimeout(priority: number, interval: number, func: () => boolean) {
         const timeoutId = GLib.timeout_add(priority, interval, () => {
-            func();
-            this.clearTimeoutId(timeoutId);
-            return GLib.SOURCE_REMOVE;
+            const source = func();
+            if (source == GLib.SOURCE_REMOVE) {
+                this.clearTimeoutId(timeoutId);
+            }
+            return source;
         });
         this.timeoutIdList.push(timeoutId);
         return timeoutId;

--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -104,8 +104,8 @@ export function initDebug() {
                 MsDndManager,
                 MsResizeManager,
                 MsWindow,
-                MsFocusManager, */
-                /* TaskBar,
+                MsFocusManager,
+                TaskBar,
                 TaskBarItem,
                 IconTaskBarItem,
                 TaskActiveIndicator,

--- a/src/widget/appPlaceholder.ts
+++ b/src/widget/appPlaceholder.ts
@@ -99,7 +99,7 @@ export class AppPlaceholder extends St.Widget {
                     break;
                 case Clutter.EventType.BUTTON_RELEASE:
                 case Clutter.EventType.TOUCH_END:
-                    this.activate(event.get_button());
+                    if (this.pressed) this.activate(event.get_button());
                     this.pressed = false;
                     break;
                 case Clutter.EventType.LEAVE:

--- a/src/widget/material/rippleBackground.ts
+++ b/src/widget/material/rippleBackground.ts
@@ -55,7 +55,7 @@ export class RippleWave extends St.Widget {
             opacity: 0,
             duration: second * 1000,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-            onComplete: () => {
+            onStopped: () => {
                 GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
                     if (!this.destroyed) {
                         this.remove_all_transitions();

--- a/src/widget/translationAnimator.ts
+++ b/src/widget/translationAnimator.ts
@@ -73,6 +73,7 @@ export class TranslationAnimator extends Clutter.Actor {
             // Remove all actors outside visible area
             const visibleArea = {
                 x1: Math.abs(translationX),
+                // We use allocation size instead of height / width getter since during transition the size doesn't follow the allocation
                 x2: Math.abs(translationX) + this.allocation.get_width(),
                 y1: Math.abs(translationY),
                 y2: Math.abs(translationY) + this.allocation.get_height(),

--- a/src/widget/translationAnimator.ts
+++ b/src/widget/translationAnimator.ts
@@ -10,7 +10,8 @@ const Me = imports.misc.extensionUtils.getCurrentExtension();
 interface TransitionConfig {
     duration: number;
     mode: Clutter.AnimationMode;
-    onComplete: () => void;
+    onComplete?: () => void;
+    onStopped?: () => void;
     translation_y?: number;
     translation_x?: number;
 }
@@ -147,7 +148,7 @@ export class TranslationAnimator extends Clutter.Actor {
         const transitionConfig: TransitionConfig = {
             duration: 250,
             mode: Clutter.AnimationMode.EASE_OUT_QUAD,
-            onComplete: () => {
+            onStopped: () => {
                 this.endTransition();
             },
         };


### PR DESCRIPTION
While inspecting the logs it's seem that while creating a new window the placeholder find a way to activate himself which isn't wanted.

From my investigation it's could be related to a ghost stage event and therefore I enforce the need of a proper click to activate it (Mouse down + mouse up)

EDIT: 16/12/22
After updating my system I face the proper issue which seem to be related to a change in transition behavior of Clutter.Actor.
It's seem that when an actor is reparented it's drop all current transition and therefore create a bug in MS.
I fixed it by completing the animation when the animation is interrupted.

I also fixed and unrelated issue in our interval code 