### PR TITLE
Update org.gnome.shell.extensions.materialshell.theme.gschema.xml

### DIFF
--- a/schemas/org.gnome.shell.extensions.materialshell.theme.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.materialshell.theme.gschema.xml
@@ -51,7 +51,7 @@
         <key name="panel-size" type="i">
             <default>48</default>
             <summary>Panels size</summary>
-            <description>Width of the vertical panel and height of the horizontal panels.</description>
+            <description>Width of the vertical panel and height of the horizontal panels. Modifying this may lead to blurry icons.</description>
         </key>
         <key name="panel-opacity" type="i">
             <default>100</default>


### PR DESCRIPTION
warn users that modifying panel size value can lead to blurry icons