### PR TITLE
Add Gnome 44 support.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
         "40",
         "41",
         "42",
-        "43"
+        "43",
+        "44"
     ],
     "bindings": "org.gnome.shell.extensions.materialshell.bindings",
     "layouts": "org.gnome.shell.extensions.materialshell.layouts",


### PR DESCRIPTION
Gnome 44 will be released on 2023-03-22, and with the release candidate some testing can be done. I did that and this release does not seem to have breaking changes for the extension.