### PR TITLE
fix: Update statusArea.ts to handle optional appMenu container

### DIFF
--- a/src/layout/verticalPanel/statusArea.ts
+++ b/src/layout/verticalPanel/statusArea.ts
@@ -159,7 +159,7 @@ export class MsStatusArea extends Clutter.Actor {
                 return (
                     actor !=
                         this.gnomeShellPanel.statusArea.activities.container &&
-                    actor != this.gnomeShellPanel.statusArea.appMenu.container
+                    actor != this.gnomeShellPanel.statusArea?.appMenu?.container
                 );
             })
             .forEach((actor) => {


### PR DESCRIPTION
I was unable to successfully enable this extension until I made this change 

The code in statusArea.ts has been updated to handle the case where the appMenu or its container is optional. prevents a crash as seen in the logs i provided on your pr upstream