### PR TITLE
fix crash on null reference call to Util.ensureActorVisibleInScrollView

### DIFF
--- a/src/layout/verticalPanel/extendedPanelContent.ts
+++ b/src/layout/verticalPanel/extendedPanelContent.ts
@@ -54,7 +54,7 @@ export class ExtendedPanelContent extends St.BoxLayout {
 
         this.searchResultList = new SearchResultList(this.searchEntry);
         this.searchResultList.connect('result-selected-changed', (_, res) => {
-            Util.ensureActorVisibleInScrollView(this.scrollView, res);
+            Util?.ensureActorVisibleInScrollView(this.scrollView, res);
         });
         this.scrollView.add_actor(this.searchResultList);
 


### PR DESCRIPTION
```
JS ERROR: TypeError: Util.ensureActorVisibleInScrollView is not a function
                                           _init/<@file:///home/alice/.local/share/gnome-shell/extensions/material-shell@papyelgringo/extension.js:5833:>
                                           selectResult@file:///home/alice/.local/share/gnome-shell/extensions/material-shell@papyelgringo/extension.js:>
                                           updateAllApplicationResults@file:///home/alice/.local/share/gnome-shell/extensions/material-shell@papyelgring>
                                           reloadRemoteProviders@file:///home/alice/.local/share/gnome-shell/extensions/material-shell@papyelgringo/exte>
                                           @resource:///org/gnome/shell/ui/init.js:21:20
                                           ```