### PR TITLE
Gnome 46 compatibility

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,10 @@
     "description": "A modern desktop interface for Linux - packaged as an extension for GNOME Shell. Improve your user experience and get rid of the anarchy of traditional desktop workflows. Designed to simplify navigation and reduce the need to manipulate windows in order to improve productivity. It's meant to be 100% predictable and bring the benefits of tools coveted by professionals to everyone.",
     "uuid": "material-shell@papyelgringo",
     "url": "https://material-shell.com",
-    "shell-version": ["45"],
+    "shell-version": [
+        "45",
+        "46"
+    ],
     "bindings": "org.gnome.shell.extensions.materialshell.bindings",
     "layouts": "org.gnome.shell.extensions.materialshell.layouts",
     "theme": "org.gnome.shell.extensions.materialshell.theme",

--- a/src/layout/msWorkspace/horizontalPanel/layoutSwitcher.ts
+++ b/src/layout/msWorkspace/horizontalPanel/layoutSwitcher.ts
@@ -78,7 +78,7 @@ export class LayoutSwitcher extends St.BoxLayout {
             this.updateLayoutWidget.bind(this)
         );
         this.menu = this.buildMenu();
-        Main.layoutManager.uiGroup.add_actor(this.menu.actor);
+        Main.layoutManager.uiGroup.add_child(this.menu.actor);
         this.menuManager.addMenu(this.menu);
 
         this.connect('destroy', () => {

--- a/src/layout/msWorkspace/horizontalPanel/taskBar.ts
+++ b/src/layout/msWorkspace/horizontalPanel/taskBar.ts
@@ -470,7 +470,7 @@ export class TileableItem extends TaskBarItem {
             })
         );
         this.menu.box.add_child(item); */
-        Main.layoutManager.uiGroup.add_actor(this.menu.actor);
+        Main.layoutManager.uiGroup.add_child(this.menu.actor);
         this.menu.actor.hide();
         // TITLE
         this.title = new St.Label({

--- a/src/layout/verticalPanel/extendedPanelContent.ts
+++ b/src/layout/verticalPanel/extendedPanelContent.ts
@@ -56,7 +56,7 @@ export class ExtendedPanelContent extends St.BoxLayout {
         this.searchResultList.connect('result-selected-changed', (_, res) => {
             Util?.ensureActorVisibleInScrollView(this.scrollView, res);
         });
-        this.scrollView.add_actor(this.searchResultList);
+        this.scrollView.add_child(this.searchResultList);
 
         this.add_child(this.scrollView);
     }

--- a/src/layout/verticalPanel/statusArea.ts
+++ b/src/layout/verticalPanel/statusArea.ts
@@ -166,7 +166,7 @@ export class MsStatusArea extends Clutter.Actor {
                 this.stealActor(actor, this.leftBoxActors);
             });
         const leftBoxActorAddedSignal = this.gnomeShellPanel._leftBox.connect(
-            'actor-added',
+            'child-added',
             (_, actor) => {
                 this.stealActor(actor, this.leftBoxActors);
             }
@@ -176,7 +176,7 @@ export class MsStatusArea extends Clutter.Actor {
         });
         const centerBoxActorAddedSignal =
             this.gnomeShellPanel._centerBox.connect(
-                'actor-added',
+                'child-added',
                 (_, actor) => {
                     this.stealActor(actor, this.centerBoxActors);
                 }
@@ -188,7 +188,7 @@ export class MsStatusArea extends Clutter.Actor {
                 this.stealActor(actor, this.rightBoxActors);
             });
         const rightBoxActorAddedSignal = this.gnomeShellPanel._rightBox.connect(
-            'actor-added',
+            'child-added',
             (_, actor) => {
                 this.stealActor(actor, this.rightBoxActors);
             }

--- a/src/layout/verticalPanel/workspaceList.ts
+++ b/src/layout/verticalPanel/workspaceList.ts
@@ -406,7 +406,7 @@ export class WorkspaceButton extends MatButton {
         });
 
         rootMenu.addMenuItem(subMenu);
-        Main.layoutManager.uiGroup.add_actor(rootMenu.actor);
+        Main.layoutManager.uiGroup.add_child(rootMenu.actor);
         rootMenu.close();
 
         return {

--- a/src/manager/msThemeManager.ts
+++ b/src/manager/msThemeManager.ts
@@ -50,7 +50,7 @@ export const msThemeSignalEnum = {
 
 function parseCoglColor(color: string): Cogl.Color {
     const c = new Cogl.Color();
-    c.init_from_4ub(
+    c.init_from_4f(
         parseInt(color.substring(1, 3), 16),
         parseInt(color.substring(3, 5), 16),
         parseInt(color.substring(5, 7), 16),

--- a/src/widget/reorderableList.ts
+++ b/src/widget/reorderableList.ts
@@ -62,7 +62,7 @@ export class ReorderableList extends Clutter.Actor {
         this.vertical = vertical;
         this.classAccepted = classAccepted;
         this.dragInProgress = false;
-        this.connect('actor-added', (_, actor) => {
+        this.connect('child-added', (_, actor) => {
             if (!actor._draggable && actor !== this.placeHolder)
                 this.makeActorDraggable(actor);
         });


### PR DESCRIPTION
Issue: https://github.com/material-shell/material-shell/issues/991

Documentation used for the upgrade:
https://gjs.guide/extensions/upgrading/gnome-shell-46.html
https://mutter.gnome.org/cogl/struct.Color.html

The [`Shell.BlurEffect`](https://gjs.guide/extensions/upgrading/gnome-shell-46.html#shell-blureffect) should change from using `sigma` to `radius`, but this requires an update to the TypeScript definitions and I haven't looked into that yet.

There are a couple of references to [`Clutter.Container`](https://gjs.guide/extensions/upgrading/gnome-shell-46.html#clutter-container) which will probably need replacing.

There are some further details in the GJS upgrade guide regarding the following which may be relevant, but I haven't had time to look into it yet:
- `DateMenu.MessagesIndicator`
- `MessageTray`
- `PopupMenu`

This is my first look at a Gnome extension's source code, so if I've done anything wrong or need to do any additional steps then just let me know. At the moment this PR gets the extension running again for me. I have not tested much of the functionality yet, and I do not know if it is backwards compatible with v45.

To give this a test you can follow the [manual installation notes](https://github.com/material-shell/material-shell?tab=readme-ov-file#get-the-most-up-to-date-version-with-git) and switch to this branch.